### PR TITLE
Bug fixes

### DIFF
--- a/TGM/src/main/java/com/minehut/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/com/minehut/tgm/command/CycleCommands.java
@@ -294,6 +294,10 @@ public class CycleCommands {
     }
 
     public static void attemptJoinTeam(Player player, MatchTeam matchTeam, boolean autoJoin, boolean ignoreFull) {
+        if (!ignoreFull && autoJoin && !player.hasPermission("tgm.pickteam") && !TGM.get().getModule(TeamManagerModule.class).getTeam(player).isSpectator()) {
+            player.sendMessage(ChatColor.RED + "You are already in a team.");
+            return;
+        }
         if (matchTeam.getMembers().size() >= matchTeam.getMax() && !ignoreFull) {
             player.sendMessage(ChatColor.RED + "Team is full! Wait for a spot to open up.");
             return;

--- a/TGM/src/main/java/com/minehut/tgm/match/MatchManifest.java
+++ b/TGM/src/main/java/com/minehut/tgm/match/MatchManifest.java
@@ -60,6 +60,7 @@ public abstract class MatchManifest {
         modules.add(new DisabledCommandsModule());
         modules.add(new PointsModule());
         modules.add(new LegacyDamageModule());
+        modules.add(new EntityDamageModule());
         modules.add(new FireworkDamageModule());
         modules.add(new GameRuleModule());
         modules.add(new ItemRemoveModule());

--- a/TGM/src/main/java/com/minehut/tgm/modules/EntityDamageModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/EntityDamageModule.java
@@ -1,0 +1,31 @@
+package com.minehut.tgm.modules;
+
+import com.minehut.tgm.match.MatchModule;
+import org.bukkit.entity.Damageable;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.projectiles.ProjectileSource;
+
+/**
+ * Created by Jorge on 9/24/2017.
+ */
+public class EntityDamageModule extends MatchModule implements Listener {
+
+    @EventHandler
+    public void onProjectileHit(ProjectileHitEvent event) {
+        if (event.getEntityType() != EntityType.FISHING_HOOK &&
+            event.getEntityType() != EntityType.SNOWBALL &&
+            event.getEntityType() != EntityType.EGG) return;
+        ProjectileSource shooter = ((Projectile) event.getEntity()).getShooter();
+        if (shooter != null && shooter instanceof Player && event.getHitEntity() instanceof Damageable) {
+            ((Damageable) event.getHitEntity()).damage(0.01, (Player) shooter);
+        }
+
+    }
+
+}

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpawnPointHandlerModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpawnPointHandlerModule.java
@@ -62,6 +62,7 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
         if (matchTeam.isSpectator()) {
             spectatorModule.applySpectatorKit(playerContext);
             if (teleport) {
+                playerContext.getPlayer().setFallDistance(0);
                 playerContext.getPlayer().teleport(getTeamSpawn(matchTeam).getLocation());
             }
         } else {
@@ -69,6 +70,7 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
             playerContext.getPlayer().updateInventory();
 
             if (teleport) {
+                playerContext.getPlayer().setFallDistance(0);
                 playerContext.getPlayer().teleport(getTeamSpawn(matchTeam).getLocation());
                 playerContext.getPlayer().setGameMode(GameMode.SURVIVAL);
             }

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpawnPointHandlerModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpawnPointHandlerModule.java
@@ -62,7 +62,6 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
         if (matchTeam.isSpectator()) {
             spectatorModule.applySpectatorKit(playerContext);
             if (teleport) {
-                playerContext.getPlayer().setFallDistance(0);
                 playerContext.getPlayer().teleport(getTeamSpawn(matchTeam).getLocation());
             }
         } else {
@@ -70,7 +69,6 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
             playerContext.getPlayer().updateInventory();
 
             if (teleport) {
-                playerContext.getPlayer().setFallDistance(0);
                 playerContext.getPlayer().teleport(getTeamSpawn(matchTeam).getLocation());
                 playerContext.getPlayer().setGameMode(GameMode.SURVIVAL);
             }

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
@@ -249,7 +249,7 @@ public class SpectatorModule extends MatchModule implements Listener {
     }
     
     @EventHandler
-    public void onPlayerInteractEntity(PlayerInteractEntityEvent event){
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
         if (isSpectating(event.getPlayer())) {
             event.setCancelled(true);
         }
@@ -275,9 +275,8 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onHangingDestroy(HangingBreakByEntityEvent event){ // Item Frames and Paintings
-        if (event.getRemover() != null && event.getRemover() instanceof Player){
-            Player remover = (Player) event.getRemover();
-            if (isSpectating(remover)) {
+        if (event.getRemover() != null && event.getRemover() instanceof Player) {
+            if (isSpectating((Player) event.getRemover())) {
                 event.setCancelled(true);
             }
         }
@@ -285,19 +284,17 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onVehicleDamage(VehicleDamageEvent event){
-        if (event.getAttacker() != null && event.getAttacker() instanceof Player){
-            Player attacker = (Player) event.getAttacker();
-            if (isSpectating(attacker)) {
+        if (event.getAttacker() != null && event.getAttacker() instanceof Player) {
+            if (isSpectating((Player) event.getAttacker())) {
                 event.setCancelled(true);
             }
         }
     }
 
     @EventHandler
-    public void onVehicleDestroy(VehicleDestroyEvent event){
+    public void onVehicleDestroy(VehicleDestroyEvent event) {
         if (event.getAttacker() != null && event.getAttacker() instanceof Player){
-            Player attacker = (Player) event.getAttacker();
-            if (isSpectating(attacker)) {
+            if (isSpectating((Player) event.getAttacker())) {
                 event.setCancelled(true);
             }
         }

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
@@ -274,7 +274,7 @@ public class SpectatorModule extends MatchModule implements Listener {
     }
 
     @EventHandler
-    public void onHangingDestroy(HangingBreakByEntityEvent event){ // Item Frames and Paintings
+    public void onHangingDestroy(HangingBreakByEntityEvent event) { // Item Frames and Paintings
         if (event.getRemover() != null && event.getRemover() instanceof Player) {
             if (isSpectating((Player) event.getRemover())) {
                 event.setCancelled(true);
@@ -283,7 +283,7 @@ public class SpectatorModule extends MatchModule implements Listener {
     }
 
     @EventHandler
-    public void onVehicleDamage(VehicleDamageEvent event){
+    public void onVehicleDamage(VehicleDamageEvent event) {
         if (event.getAttacker() != null && event.getAttacker() instanceof Player) {
             if (isSpectating((Player) event.getAttacker())) {
                 event.setCancelled(true);
@@ -293,7 +293,7 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onVehicleDestroy(VehicleDestroyEvent event) {
-        if (event.getAttacker() != null && event.getAttacker() instanceof Player){
+        if (event.getAttacker() != null && event.getAttacker() instanceof Player) {
             if (isSpectating((Player) event.getAttacker())) {
                 event.setCancelled(true);
             }

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
@@ -24,6 +24,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
@@ -267,6 +268,16 @@ public class SpectatorModule extends MatchModule implements Listener {
     public void onDrop(PlayerDropItemEvent event) {
         if (isSpectating(event.getPlayer())) {
             event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onHangingDestroy(HangingBreakByEntityEvent event){ // Item Frames and Paintings
+        if (event.getRemover() != null && event.getRemover() instanceof Player){
+            Player remover = (Player) event.getRemover();
+            if (isSpectating(remover)) {
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
@@ -198,7 +198,7 @@ public class SpectatorModule extends MatchModule implements Listener {
                 event.setCancelled(true); //
                 event.getEntity().setVelocity(new Vector(event.getEntity().getVelocity().getX(),
                         event.getEntity().getVelocity().getZ() + 10.0, event.getEntity().getVelocity().getZ()));
-
+                ((Player) event.getEntity()).setAllowFlight(true); // Prevent IllegalArgumentException: Cannot make player fly if getAllowFlight() is false.
                 ((Player) event.getEntity()).setFlying(true);
             }
         }

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
@@ -36,6 +36,8 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import java.util.Arrays;

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
@@ -30,6 +30,8 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
+import org.bukkit.event.vehicle.VehicleDamageEvent;
+import org.bukkit.event.vehicle.VehicleDestroyEvent;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -276,6 +278,26 @@ public class SpectatorModule extends MatchModule implements Listener {
         if (event.getRemover() != null && event.getRemover() instanceof Player){
             Player remover = (Player) event.getRemover();
             if (isSpectating(remover)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onVehicleDamage(VehicleDamageEvent event){
+        if (event.getAttacker() != null && event.getAttacker() instanceof Player){
+            Player attacker = (Player) event.getAttacker();
+            if (isSpectating(attacker)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onVehicleDestroy(VehicleDestroyEvent event){
+        if (event.getAttacker() != null && event.getAttacker() instanceof Player){
+            Player attacker = (Player) event.getAttacker();
+            if (isSpectating(attacker)) {
                 event.setCancelled(true);
             }
         }

--- a/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/SpectatorModule.java
@@ -155,6 +155,7 @@ public class SpectatorModule extends MatchModule implements Listener {
 
     public void applySpectatorKit(PlayerContext playerContext) {
         Players.reset(playerContext.getPlayer(), false);
+        playerContext.getPlayer().addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 100000, 255, false, false));
         playerContext.getPlayer().setGameMode(GameMode.ADVENTURE);
         playerContext.getPlayer().setAllowFlight(true);
         playerContext.getPlayer().setFlying(true);

--- a/TGM/src/main/java/com/minehut/tgm/modules/ctw/CTWModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/ctw/CTWModule.java
@@ -28,6 +28,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -112,6 +113,15 @@ public class CTWModule extends MatchModule implements Listener {
                         TGM.get().getMatchManager().endMatch(matchTeam);
                     }
                 }
+
+                 @Override
+                 public void drop(Player player, MatchTeam matchTeam, boolean broadcast) {
+                    updateOnScoreboard(woolObjective);
+
+                     if (broadcast) Bukkit.broadcastMessage(matchTeam.getColor() + player.getName() + ChatColor.WHITE +
+                             " dropped " + woolObjective.getChatColor() + ChatColor.BOLD.toString() + woolObjective.getName());
+                 }
+
             });
         }
 

--- a/TGM/src/main/java/com/minehut/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/infection/InfectionModule.java
@@ -52,14 +52,15 @@ public class InfectionModule extends MatchModule implements Listener {
     @Override
     public void enable() {
         int players = teamManager.getTeamById("humans").getMembers().size();
-        int zombies = (int)(players * (5 / 100.0F)) == 0 ? 1 : (int)(players * (5 / 100.0F));
+        int zombies = ((int) (players * (5 / 100.0F)) == 0 ? 1 : (int) (players * (5 / 100.0F))) - teamManager.getTeamById("infected").getMembers().size();
+        if (zombies > 0) {
+            for (int i = 0; i < zombies; i++) {
+                PlayerContext player = teamManager.getTeamById("humans").getMembers().get(new Random().nextInt(teamManager.getTeamById("humans").getMembers().size()));
+                broadcastMessage(String.format("&2&l%s &7has been infected!", player.getPlayer().getName()));
 
-        for (int i = 0; i < zombies; i++) {
-            PlayerContext player = teamManager.getTeamById("humans").getMembers().get(new Random().nextInt(teamManager.getTeamById("humans").getMembers().size()));
-            broadcastMessage(String.format("&2&l%s &7has been infected!", player.getPlayer().getName()));
-
-            infect(player.getPlayer());
-            freeze(player.getPlayer());
+                infect(player.getPlayer());
+                freeze(player.getPlayer());
+            }
         }
 
         for (MatchTeam team : teamManager.getTeams()) {

--- a/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjective.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjective.java
@@ -82,7 +82,7 @@ public class WoolObjective implements Listener {
             }
         }
         else {
-            if (podium.contains(event.getBlockPlaced().getLocation())){
+            if (podium.contains(event.getBlockPlaced().getLocation())) {
                 event.setCancelled(true);
             }
         }

--- a/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjective.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjective.java
@@ -80,8 +80,7 @@ public class WoolObjective implements Listener {
                     woolObjectiveService.place(event.getPlayer(), matchTeam, event.getBlock());
                 }
             }
-        }
-        else {
+        } else {
             if (podium.contains(event.getBlockPlaced().getLocation())) {
                 event.setCancelled(true);
             }
@@ -164,7 +163,7 @@ public class WoolObjective implements Listener {
     }
 
     @EventHandler
-    public void onTeamChange(TeamChangeEvent event){
+    public void onTeamChange(TeamChangeEvent event) {
         handleWoolDrop(event.getPlayerContext().getPlayer());
         if (touches.containsKey(event.getPlayerContext().getPlayer().getUniqueId())) {
             touches.remove(event.getPlayerContext().getPlayer().getUniqueId());
@@ -175,7 +174,7 @@ public class WoolObjective implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    public void onQuit(PlayerQuitEvent event){
+    public void onQuit(PlayerQuitEvent event) {
         handleWoolDrop(event.getPlayer());
     }
 

--- a/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjective.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjective.java
@@ -4,20 +4,25 @@ import com.minehut.tgm.TGM;
 import com.minehut.tgm.modules.TimeModule;
 import com.minehut.tgm.modules.region.Region;
 import com.minehut.tgm.modules.team.MatchTeam;
+import com.minehut.tgm.modules.team.TeamChangeEvent;
 import com.minehut.tgm.modules.team.TeamManagerModule;
 import com.minehut.tgm.util.ColorConverter;
 import lombok.Getter;
 import lombok.Setter;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,28 +59,31 @@ public class WoolObjective implements Listener {
 
     @EventHandler
     public void onPlace(BlockPlaceEvent event) {
-        if (event.getBlockPlaced().getType() == Material.WOOL) {
-            if ((event.getBlockPlaced().getState().getData().getData() == color)) {
-                if (!completed) {
+        if (event.getBlockPlaced().getType() == Material.WOOL && event.getBlockPlaced().getState().getData().getData() == color) {
+            if (!completed) {
 
-                    if (!podium.contains(event.getBlockPlaced().getLocation())) {
-                        return;
-                    }
-
-                    if (!owner.containsPlayer(event.getPlayer())) {
-                        return;
-                    }
-
-                    event.setCancelled(false); //override filter
-                    setCompleted(true);
-
-                    TeamManagerModule teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
-                    MatchTeam matchTeam = teamManagerModule.getTeam(event.getPlayer());
-
-                    for (WoolObjectiveService woolObjectiveService : services) {
-                        woolObjectiveService.place(event.getPlayer(), matchTeam, event.getBlock());
-                    }
+                if (!podium.contains(event.getBlockPlaced().getLocation())) {
+                    return;
                 }
+
+                if (!owner.containsPlayer(event.getPlayer())) {
+                    return;
+                }
+
+                event.setCancelled(false); //override filter
+                setCompleted(true);
+
+                TeamManagerModule teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
+                MatchTeam matchTeam = teamManagerModule.getTeam(event.getPlayer());
+
+                for (WoolObjectiveService woolObjectiveService : services) {
+                    woolObjectiveService.place(event.getPlayer(), matchTeam, event.getBlock());
+                }
+            }
+        }
+        else {
+            if (podium.contains(event.getBlockPlaced().getLocation())){
+                event.setCancelled(true);
             }
         }
     }
@@ -127,6 +135,48 @@ public class WoolObjective implements Listener {
                 handleWoolPickup((Player) event.getWhoClicked());
             }
         }
+    }
+
+    private void handleWoolDrop(Player player) {
+        if (completed) return;
+
+        if (!owner.containsPlayer(player)) {
+            return;
+        }
+
+        if (!touches.containsKey(player.getUniqueId())) {
+            return;
+        }
+        touches.remove(player.getUniqueId());
+        boolean broadcast = touches.isEmpty();
+
+        TeamManagerModule teamManagerModule = TGM.get().getModule(TeamManagerModule.class);
+        MatchTeam matchTeam = teamManagerModule.getTeam(player);
+
+        for (WoolObjectiveService woolObjectiveService : services) {
+            woolObjectiveService.drop(player, matchTeam, broadcast);
+        }
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        handleWoolDrop(event.getEntity());
+    }
+
+    @EventHandler
+    public void onTeamChange(TeamChangeEvent event){
+        handleWoolDrop(event.getPlayerContext().getPlayer());
+        if (touches.containsKey(event.getPlayerContext().getPlayer().getUniqueId())) {
+            touches.remove(event.getPlayerContext().getPlayer().getUniqueId());
+        }
+        for (WoolObjectiveService woolObjectiveService : services) {
+            woolObjectiveService.drop(event.getPlayerContext().getPlayer(), event.getOldTeam(), false);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onQuit(PlayerQuitEvent event){
+        handleWoolDrop(event.getPlayer());
     }
 
     public WoolStatus getStatus() {

--- a/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjectiveService.java
+++ b/TGM/src/main/java/com/minehut/tgm/modules/wool/WoolObjectiveService.java
@@ -8,4 +8,6 @@ public interface WoolObjectiveService {
     void pickup(Player player, MatchTeam matchTeam, boolean firstTouch);
 
     void place(Player player, MatchTeam matchTeam, Block block);
+
+    void drop(Player player, MatchTeam matchTeam, boolean broadcast);
 }

--- a/TGM/src/main/java/com/minehut/tgm/util/Players.java
+++ b/TGM/src/main/java/com/minehut/tgm/util/Players.java
@@ -16,9 +16,15 @@ public class Players {
         player.setSaturation(20);
         player.getInventory().clear();
         player.getInventory().setArmorContents(new ItemStack[]{new ItemStack(Material.AIR), new ItemStack(Material.AIR), new ItemStack(Material.AIR), new ItemStack(Material.AIR)});
+        
+        player.getActivePotionEffects().forEach(potionEffect -> {
+            try {
+                player.removePotionEffect(potionEffect.getType());
+            } catch (NullPointerException ignored) {}
+        });
 
-        player.getActivePotionEffects().stream().findAny().ifPresent(potionEffect -> player.removePotionEffect(potionEffect.getType()));
-
+        player.setFireTicks(0);
+        player.setFallDistance(0);
         player.setTotalExperience(0);
         player.setExp(0);
         player.setLevel(0);

--- a/TGM/src/main/java/com/minehut/tgm/util/Players.java
+++ b/TGM/src/main/java/com/minehut/tgm/util/Players.java
@@ -31,6 +31,7 @@ public class Players {
         player.setWalkSpeed(0.2F);
         player.setFlySpeed(0.1F);
 
+        player.setSneaking(false);
         player.setInvulnerable(false);
         player.setCanPickupItems(true);
         player.setCollidable(true);


### PR DESCRIPTION
Bugs fixed:
- Players taking fall damage after being teleported to spawnpoint when the match starts https://github.com/WarzoneMC/Warzone/issues/69
- Spectators can break item frames and paintings
- Spectators can break boats, minecarts and other vehicles
- Players able to use the autojoin item again to team stack
- Error on console if spectator takes void damage and does not have flight enabled
- CTW: wool objectives not displaying true status after first touch
- CTW: Players can place any block in wool place regions
- Eggs, snowballs and fishing rods don't deal knockback https://github.com/WarzoneMC/Warzone/issues/77
- Add weakness to spectators https://github.com/WarzoneMC/Warzone/issues/65
- Infection: Donators or Operators being able to join humans after the game started https://github.com/WarzoneMC/Warzone/issues/60