### PR TITLE
Add /togglechat command for staff

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -241,7 +241,7 @@ public class PunishCommands {
             TGM.get().saveConfig();
             Bukkit.broadcastMessage(ChatColor.DARK_AQUA + sender.getName() + " unmuted the chat.");
         }
-    }    
+    }
 
     private static void issuePunishment(String type, String name, CommandSender punisher, String verb, TimeUnitPair timeUnitPair, String reason, boolean time, boolean broadcast) {
         issuePunishment(type, name, null, false, punisher, verb, timeUnitPair, reason, time, broadcast);

--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -229,6 +229,20 @@ public class PunishCommands {
         Bukkit.getConsoleSender().sendMessage(result);
     }
 
+    @Command(aliases = {"togglechat", "freezechat"}, desc = "Toggle server chat.")
+    @CommandPermissions({"tgm.togglechat"})
+    public static void togglechat(CommandContext cmd, CommandSender sender) {
+        if (TGM.get().getConfig().getBoolean("chat.enabled")) {
+            TGM.get().getConfig().set("chat.enabled", false);
+            TGM.get().saveConfig();
+            Bukkit.broadcastMessage(ChatColor.DARK_AQUA + sender.getName() + " muted the chat.");
+        } else {
+            TGM.get().getConfig().set("chat.enabled", true);
+            TGM.get().saveConfig();
+            Bukkit.broadcastMessage(ChatColor.DARK_AQUA + sender.getName() + " unmuted the chat.");
+        }
+    }    
+
     private static void issuePunishment(String type, String name, CommandSender punisher, String verb, TimeUnitPair timeUnitPair, String reason, boolean time, boolean broadcast) {
         issuePunishment(type, name, null, false, punisher, verb, timeUnitPair, reason, time, broadcast);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/ChatModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ChatModule.java
@@ -40,7 +40,7 @@ public class ChatModule extends MatchModule implements Listener {
         timeModule = match.getModule(TimeModule.class);
     }
 
-    private final List<String> blockdCmds = Arrays.asList("t ", "w ", "r ", "reply", "minecraft:w", "tell", "minecraft:tell", "minecraft:t ", "msg", "minecraft:msg");
+    private final List<String> blockedCmds = Arrays.asList("t ", "w ", "r ", "reply", "minecraft:w", "tell", "minecraft:tell", "minecraft:t ", "msg", "minecraft:msg");
 
     @EventHandler
     public void onCommand(PlayerCommandPreprocessEvent event) {
@@ -53,7 +53,7 @@ public class ChatModule extends MatchModule implements Listener {
     }
 
     private boolean startsWith(String msg) {
-        for (String cmd : blockdCmds) {
+        for (String cmd : blockedCmds) {
             if (msg.toLowerCase().startsWith("/" + cmd) || msg.toLowerCase().startsWith(cmd)) return true;
         }
         return false;

--- a/TGM/src/main/java/network/warzone/tgm/modules/ChatModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ChatModule.java
@@ -61,6 +61,14 @@ public class ChatModule extends MatchModule implements Listener {
 
     @EventHandler(priority = EventPriority.LOW)
     public void onChat(AsyncPlayerChatEvent event) {
+        // Run this code if the chat is currently muted
+        if (!TGM.get().getConfig().getBoolean("chat.enabled")) {
+            if (!event.getPlayer().hasPermission("tgm.togglechat.bypass")) {
+                event.getPlayer().sendMessage(ChatColor.RED + "Chat is currently disabled. If you think this is wrong, please contact a staff member on our Discord.");
+                event.setCancelled(true);
+                return;
+            }
+        }
         PlayerContext playerContext = TGM.get().getPlayerManager().getPlayerContext(event.getPlayer());
         if (playerContext.getUserProfile().getLatestMute() != null && playerContext.getUserProfile().getLatestMute().isActive()) {
             Punishment punishment = playerContext.getUserProfile().getLatestMute();

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -5,6 +5,8 @@ api:
   stats:
     enabled: true
 rotation: maps/rotation.txt
+chat:
+  enabled: true
 map:
   sources:
   - maps


### PR DESCRIPTION
This PR adds a command /togglechat (aliases: /mutechat) for anyone with the permission **tgm.togglechat**. Anyone with the permission **tgm.togglechat.bypass** is able to bypass the chat mute. 

I added a new config option (**chat.enabled**). I'm not sure if your setup automatically deals with configuration but if not, you're gonna have to add that to the config.

This PR fixes issue #148.