### PR TITLE
Fixed killer player not being colored when they use fire

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/DeathMessageModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/DeathMessageModule.java
@@ -64,7 +64,7 @@ public class DeathMessageModule extends MatchModule implements Listener {
                         killerTeam.getColor() + module.getKillerName() + ChatColor.GRAY + " from " + distance + " blocks";
             } else if (cause.equals(DamageCause.FIRE) || cause.equals(DamageCause.FIRE_TICK)) {
                 if (!module.getPlayerName().equals(module.getKillerName())) {
-                    message = playerTeam.getColor() + module.getPlayerName() + ChatColor.GRAY + " was burned to death by " + module.getKillerName();
+                    message = playerTeam.getColor() + module.getPlayerName() + ChatColor.GRAY + " was burned to death by " + killerTeam.getColor() + module.getKillerName() +ChatColor.GRAY;
                 } else {
                     message = playerTeam.getColor() + module.getPlayerName() + ChatColor.GRAY + " burned to death";
                 }


### PR DESCRIPTION
*This is not tested, so use with caution

Whenever you kill someone with fire, your username is gray when it shows the death message in chat. This bothers me and my OCD.