### PR TITLE
Fix /setnext

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -202,7 +202,7 @@ public class CycleCommands {
         if (cmd.argsLength() > 0) {
             MapContainer found = null;
             for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
-                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(cmd.getJoinedStrings(0))) {
+                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(cmd.getJoinedStrings(0).toLowerCase())) {
                     found = mapContainer;
                 }
             }

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -206,9 +206,12 @@ public class CycleCommands {
                     found = mapContainer;
                 }
             }
-            for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
-                if (mapContainer.getMapInfo().getName().toLowerCase().startsWith(cmd.getJoinedStrings(0).toLowerCase())) {
-                    found = mapContainer;
+            
+            if (found == null) {
+                for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
+                    if (mapContainer.getMapInfo().getName().toLowerCase().startsWith(cmd.getJoinedStrings(0).toLowerCase())) {
+                        found = mapContainer;
+                    }
                 }
             }
 

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -202,7 +202,7 @@ public class CycleCommands {
         if (cmd.argsLength() > 0) {
             MapContainer found = null;
             for (MapContainer mapContainer : TGM.get().getMatchManager().getMapLibrary().getMaps()) {
-                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(cmd.getJoinedStrings(0).toLowerCase())) {
+                if (mapContainer.getMapInfo().getName().equalsIgnoreCase(cmd.getJoinedStrings(0))) {
                     found = mapContainer;
                 }
             }


### PR DESCRIPTION
This fixes /setnext so if as an example we have to two maps called "Balloons" and "Balloons Halloween", you will be able to set "Balloons" again. It also makes the input map name lower case in both for loops.