### PR TITLE
Add filter to disable bows

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
@@ -85,7 +85,7 @@ public class FilterManagerModule extends MatchModule {
             String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
 
             filterTypes.add(new EnterFilterType(matchTeams, regions, filterEvaluator, message));
-        } else if (type.equals("disable-bow")) {
+        } else if (type.equals("use-bow")) {
             List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
             List<Region> regions = new ArrayList<>();
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
@@ -99,7 +99,7 @@ public class FilterManagerModule extends MatchModule {
             FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
             String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
 
-            filterTypes.add(new DisableBowFilterType(matchTeams, regions, filterEvaluator, message));
+            filterTypes.add(new UseBowFilterType(matchTeams, regions, filterEvaluator, message));
         } else if (type.equals("leave")) {
             List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
             List<Region> regions = new ArrayList<>();

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
@@ -85,6 +85,21 @@ public class FilterManagerModule extends MatchModule {
             String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
 
             filterTypes.add(new EnterFilterType(matchTeams, regions, filterEvaluator, message));
+        } else if (type.equals("disable-bow")) {
+            List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
+            List<Region> regions = new ArrayList<>();
+
+            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
+                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
+                if (region != null) {
+                    regions.add(region);
+                }
+            }
+
+            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
+            String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+
+            filterTypes.add(new DisableBowFilterType(matchTeams, regions, filterEvaluator, message));
         } else if (type.equals("leave")) {
             List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
             List<Region> regions = new ArrayList<>();

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/DisableBowFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/DisableBowFilterType.java
@@ -1,0 +1,45 @@
+package network.warzone.tgm.modules.filter.type;
+ 
+import network.warzone.tgm.modules.filter.FilterResult;
+import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
+import network.warzone.tgm.modules.region.Region;
+import network.warzone.tgm.modules.team.MatchTeam;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityShootBowEvent;
+ 
+import java.util.List;
+ 
+/**
+ * Created by Vice on 9/12/2018.
+ */
+ 
+@AllArgsConstructor @Getter
+public class DisableBowFilterType implements FilterType, Listener {
+ 
+    private final List<MatchTeam> teams;
+    private final List<Region> regions;
+    private final FilterEvaluator evaluator;
+    private final String message;
+ 
+    @EventHandler
+    public void onShootBow(ShootBowEvent event) {
+        for (Region region : regions) {
+            if (region.contains(event.getBow().getLocation())) {
+                for (MatchTeam matchTeam : teams) {
+                    if (matchTeam.containsPlayer(event.getPlayer())) {
+                        FilterResult filterResult = evaluator.evaluate(event.getPlayer());
+                        if (filterResult == FilterResult.DENY) {
+                            event.setCancelled(true);
+                            event.getPlayer().sendMessage(message);
+                        } else if (filterResult == FilterResult.ALLOW) {
+                            event.setCancelled(false);
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/DisableBowFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/DisableBowFilterType.java
@@ -26,7 +26,7 @@ public class DisableBowFilterType implements FilterType, Listener {
     private final String message;
  
     @EventHandler
-    public void onShootBow(ShootBowEvent event) {
+    public void onPlayerShootArrow(EntityShootBowEvent event) {
         for (Region region : regions) {
             if (region.contains(event.getBow().getLocation())) {
                 for (MatchTeam matchTeam : teams) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/DisableBowFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/DisableBowFilterType.java
@@ -1,5 +1,5 @@
 package network.warzone.tgm.modules.filter.type;
- 
+
 import network.warzone.tgm.modules.filter.FilterResult;
 import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
 import network.warzone.tgm.modules.region.Region;
@@ -10,36 +10,33 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityShootBowEvent;
- 
+
 import java.util.List;
- 
+
 /**
- * Created by Vice on 9/12/2018.
+ * Created by Vice & Thrasilias on 9/12/2018.
  */
- 
+
 @AllArgsConstructor @Getter
 public class DisableBowFilterType implements FilterType, Listener {
- 
+
     private final List<MatchTeam> teams;
     private final List<Region> regions;
     private final FilterEvaluator evaluator;
     private final String message;
- 
+
     @EventHandler
-    public void onPlayerShootArrow(EntityShootBowEvent event) {
+    public void onShootBowTest(EntityShootBowEvent e) {
         for (Region region : regions) {
-            if (region.contains(event.getBow().getLocation())) {
-                for (MatchTeam matchTeam : teams) {
-                    if (matchTeam.containsPlayer(event.getPlayer())) {
-                        FilterResult filterResult = evaluator.evaluate(event.getPlayer());
-                        if (filterResult == FilterResult.DENY) {
-                            event.setCancelled(true);
-                            event.getPlayer().sendMessage(message);
-                        } else if (filterResult == FilterResult.ALLOW) {
-                            event.setCancelled(false);
-                        }
-                    }
+            if (region.contains(e.getEntity().getLocation())) {
+                FilterResult filterResult = evaluator.evaluate(e.getEntity());
+                if (filterResult == FilterResult.DENY) {
+                    e.setCancelled(true);
+                    e.getEntity().sendMessage(message);
+                } else if (filterResult == FilterResult.ALLOW) {
+                    e.setCancelled(false);
                 }
             }
         }
     }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseBowFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseBowFilterType.java
@@ -18,7 +18,7 @@ import java.util.List;
  */
 
 @AllArgsConstructor @Getter
-public class DisableBowFilterType implements FilterType, Listener {
+public class UseBowFilterType implements FilterType, Listener {
 
     private final List<MatchTeam> teams;
     private final List<Region> regions;


### PR DESCRIPTION
**Usage:** `use-bow`

May be useful for grace periods, arcade maps, regions in one-hit kill maps, or to prevent spawnkilling in certain areas from a distance. Lucas did a once-over on it in that it looks right, hopefully it checks out. Intended to allow the author of the map to specify a message, specify the teams, and the region.

Edits by maintainers are enabled, so commits can be added if necessary.