### PR TITLE
Broadcast team joins

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -572,6 +572,7 @@ public class CycleCommands {
 
         PlayerContext playerContext = TGM.get().getPlayerManager().getPlayerContext(player);
         TGM.get().getModule(TeamManagerModule.class).joinTeam(playerContext, matchTeam);
+        TGM.get().getServer().broadcastMessage(ChatColor.LIGHT_PURPLE + player.getName() + ChatColor.WHITE + " joined " + matchTeam.getColor() + ChatColor.BOLD + matchTeam.getAlias());
     }
 
 }


### PR DESCRIPTION
This closes #171 and it is a debatable addition.

Maybe someone can add a command to toggle receiving of the messages, though I'm not sure I want to create a per-player-settings system right now.

**What does this pull request add?**
Whenever a player joins a team with /join or the Team Selector GUI, it will notify everyone on the server. More info about the purpose can be found @ #171.