### PR TITLE
Add filter to disable shears

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
@@ -100,6 +100,25 @@ public class FilterManagerModule extends MatchModule {
             String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
 
             filterTypes.add(new UseBowFilterType(matchTeams, regions, filterEvaluator, message));
+        } else if (type.equals("use-shear")) {
+            List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
+            List<Region> regions = new ArrayList<>();
+
+            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
+                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
+                if (region != null) {
+                    regions.add(region);
+                }
+            }
+
+            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
+            String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+
+            filterTypes.add(new UseShearFilterType(matchTeams, regions, filterEvaluator, message));
+            
+          }
+            
+            
         } else if (type.equals("leave")) {
             List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
             List<Region> regions = new ArrayList<>();

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
@@ -1,0 +1,46 @@
+package network.warzone.tgm.modules.filter.type;
+
+import network.warzone.tgm.modules.filter.FilterResult;
+import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
+import network.warzone.tgm.modules.region.Region;
+import network.warzone.tgm.modules.team.MatchTeam;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerShearEntityEvent;
+
+import java.util.List;
+
+/**
+ * Created by Vice & Thrasilias on 9/14/2018.
+ */
+
+@AllArgsConstructor @Getter
+public class ShearFilterType implements FilterType, Listener {
+
+    private final List<MatchTeam> teams;
+    private final List<Region> regions;
+    private final FilterEvaluator evaluator;
+    private final String message;
+
+    @EventHandler
+    public void onShear(PlayerShearEntityEvent e) {
+        for (Region region : regions) {
+            if (region.contains(e.getPlayer().getLocation())) {
+                for (MatchTeam matchTeam : teams) {
+                    if (matchTeam.containsPlayer(e.getPlayer())) {
+                        FilterResult filterResult = evaluator.evaluate(e.getPlayer());
+                        if (filterResult == FilterResult.DENY) {
+                            e.setCancelled(true);
+                            e.getPlayer().sendMessage(message);
+                        } else if (filterResult == FilterResult.ALLOW) {
+                            e.setCancelled(false);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
@@ -6,7 +6,6 @@ import network.warzone.tgm.modules.region.Region;
 import network.warzone.tgm.modules.team.MatchTeam;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerShearEntityEvent;


### PR DESCRIPTION
Was going to make the sheep module it's own thing but development fell off. Being that this is the only thing that came to fruition, I'm making a pull request so it can be used in the future should anyone pursue the idea.

The main use for this filter is for shearing sheep on Capture the Wool: you can make it to where teams cannot shear the wool off their own team's sheep, while the enemy can.