### PR TITLE
Add playtime, wool pickups and wool placements to stats

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -9,6 +9,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.ChatColor;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.gametype.GameType;
+import network.warzone.tgm.join.JoinManager;
 import network.warzone.tgm.map.MapContainer;
 import network.warzone.tgm.map.MapInfo;
 import network.warzone.tgm.match.MatchManager;
@@ -665,6 +666,7 @@ public class CycleCommands {
                 sender.sendMessage("");
                 sender.sendMessage(ChatColor.DARK_AQUA + "   Level: " + up.getLevel());
                 sender.sendMessage(ChatColor.DARK_AQUA + "   XP: " + ChatColor.AQUA + up.getXP() + "/" + ChatColor.DARK_AQUA + UserProfile.getRequiredXP(up.getLevel() + 1) + " (approx.)");
+                sender.sendMessage(ChatColor.DARK_AQUA + "   Online time: " + ChatColor.AQUA + getFormattedPlaytime(up.getUuid(), up.getTotalPlaytime(), false));
                 sender.sendMessage("");
                 sender.sendMessage(ChatColor.DARK_AQUA + "   Kills: " + ChatColor.GREEN + up.getKills());
                 sender.sendMessage(ChatColor.DARK_AQUA + "   Deaths: " + ChatColor.RED + up.getDeaths());
@@ -683,6 +685,7 @@ public class CycleCommands {
         sender.sendMessage("");
         sender.sendMessage(ChatColor.DARK_AQUA + "   Level: " + targetUser.getLevelString().replace("[", "").replace("]", ""));
         sender.sendMessage(ChatColor.DARK_AQUA + "   XP: " + ChatColor.AQUA + targetUser.getUserProfile().getXP() + "/" + ChatColor.DARK_AQUA + UserProfile.getRequiredXP(targetUser.getUserProfile().getLevel() + 1) + " (approx.)");
+        sender.sendMessage(ChatColor.DARK_AQUA + "   Online time: " + ChatColor.AQUA + getFormattedPlaytime(targetPlayer.getUniqueId().toString(), targetUser.getUserProfile().getTotalPlaytime(), true));
         sender.sendMessage("");
         sender.sendMessage(ChatColor.DARK_AQUA + "   Kills: " + ChatColor.GREEN + targetUser.getUserProfile().getKills());
         sender.sendMessage(ChatColor.DARK_AQUA + "   Deaths: " + ChatColor.RED + targetUser.getUserProfile().getDeaths());
@@ -694,6 +697,42 @@ public class CycleCommands {
         sender.sendMessage(ChatColor.BLUE + ChatColor.STRIKETHROUGH.toString() + "-------------------------------");
     }
 
+    public static String getFormattedPlaytime(String uuid, long totalPlaytime, boolean online) {
+        double time = totalPlaytime / 1000D;
+        String playtime;
+
+        if (online) time += (System.currentTimeMillis() - JoinManager.getJoinDates().get(uuid)) / 1000D;
+
+        int months = (int) Math.floor(time / 2592000); // 1 month is 30 days here
+        time -= months * 2592000;
+        int weeks = (int) Math.floor(time / 604800);
+        time -= weeks * 604800;
+        int days = (int) Math.floor(time / 86400);
+        time -= days * 86400;
+        int hours = (int) Math.floor(time / 3600);
+        time -= hours * 3600;
+        int minutes = (int) Math.floor(time / 60);
+        time -= minutes * 60;
+        int seconds = (int) Math.floor(time);
+
+        if (months > 0) {
+            playtime = months == 1 ? "1 month" : months + " months";
+        } else if (weeks > 0) {
+            playtime = weeks == 1 ? "1 week" : weeks + " weeks";
+        } else if (days > 0) {
+            playtime = days == 1 ? " 1 day" : days + " days";
+        } else if (hours > 0) {
+            playtime = (hours == 1) ? "1 hour" : hours + " hours";
+        } else if (minutes > 0) {
+            playtime = (minutes == 1) ? "1 minute" : minutes + " minutes";
+        } else if (seconds > 0) {
+            playtime = (seconds == 1) ? "1 second" : seconds + " seconds";
+        } else {
+            playtime = "moments";
+        }
+
+        return playtime;
+    }
 
     public static void attemptJoinTeam(Player player, MatchTeam matchTeam, boolean autoJoin) {
         attemptJoinTeam(player, matchTeam, autoJoin, false);
@@ -724,8 +763,8 @@ public class CycleCommands {
         TextComponent main = new TextComponent(ChatColor.translateAlternateColorCodes('&', "&7" + place + "." + " &b" + profile.getName() + " &7(&9" + profile.getKills() + " kills&7)"));
         main.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent[]{
                 new TextComponent(ChatColor.AQUA + "Level: " + ChatColor.RESET + profile.getLevel()),
-                new TextComponent("\n"),
                 new TextComponent("\n" + ChatColor.AQUA + "XP: " + ChatColor.RESET + profile.getXP()),
+                new TextComponent("\n"),
                 new TextComponent("\n" + ChatColor.AQUA + "Kills: " + ChatColor.RESET + profile.getKills()),
                 new TextComponent("\n" + ChatColor.AQUA + "Deaths: " + ChatColor.RESET + profile.getDeaths()),
                 new TextComponent("\n" + ChatColor.AQUA + "K/D: " + ChatColor.RESET + profile.getKDR()),

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
@@ -18,11 +18,16 @@ import network.warzone.tgm.modules.time.TimeModule;
 import network.warzone.tgm.modules.wool.WoolObjective;
 import network.warzone.tgm.modules.wool.WoolObjectiveService;
 import network.warzone.tgm.modules.wool.WoolStatus;
+import network.warzone.tgm.player.event.PlayerXPEvent;
 import network.warzone.tgm.user.PlayerContext;
 import network.warzone.tgm.util.ColorConverter;
 import network.warzone.tgm.util.FireworkUtil;
 import network.warzone.tgm.util.Parser;
 import network.warzone.tgm.util.Strings;
+import network.warzone.warzoneapi.models.DestroyWoolRequest;
+import network.warzone.warzoneapi.models.UserProfile;
+import network.warzone.warzoneapi.models.WoolPickupRequest;
+import network.warzone.warzoneapi.models.WoolPlacementRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -85,6 +90,13 @@ public class CTWModule extends MatchModule implements Listener {
                                 }
                             }
                         }
+
+                        if (TGM.get().getApiManager().isStatsDisabled()) return;
+
+                        PlayerContext playerContext = TGM.get().getPlayerManager().getPlayerContext(player);
+                        playerContext.getUserProfile().addWoolPickup();
+                        Bukkit.getPluginManager().callEvent(new PlayerXPEvent(playerContext, UserProfile.XP_PER_WOOL_PICKUP, playerContext.getUserProfile().getXP() - UserProfile.XP_PER_WOOL_PICKUP, playerContext.getUserProfile().getXP()));
+                        Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> TGM.get().getTeamClient().pickupWool(new WoolPickupRequest(player.getUniqueId())));
                     }
                 }
 
@@ -110,6 +122,13 @@ public class CTWModule extends MatchModule implements Listener {
                     if (getIncompleteWools(matchTeam).isEmpty()) {
                         TGM.get().getMatchManager().endMatch(matchTeam);
                     }
+
+                    if (TGM.get().getApiManager().isStatsDisabled()) return;
+
+                    PlayerContext playerContext = TGM.get().getPlayerManager().getPlayerContext(player);
+                    playerContext.getUserProfile().addWoolPlacement();
+                    Bukkit.getPluginManager().callEvent(new PlayerXPEvent(playerContext, UserProfile.XP_PER_WOOL_PLACEMENT, playerContext.getUserProfile().getXP() - UserProfile.XP_PER_WOOL_PLACEMENT, playerContext.getUserProfile().getXP()));
+                    Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> TGM.get().getTeamClient().placeWool(new WoolPlacementRequest(player.getUniqueId())));
                 }
 
                  @Override

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -92,7 +92,6 @@ public class DTMModule extends MatchModule implements Listener {
                     playerContext.getUserProfile().addWoolDestroy();
                     Bukkit.getPluginManager().callEvent(new PlayerXPEvent(playerContext, UserProfile.XP_PER_WOOL_BREAK, playerContext.getUserProfile().getXP() - UserProfile.XP_PER_WOOL_BREAK, playerContext.getUserProfile().getXP()));
                     Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> TGM.get().getTeamClient().destroyWool(new DestroyWoolRequest(player.getUniqueId())));
-
                 }
 
                 @Override

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/TeamClient.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/TeamClient.java
@@ -23,6 +23,11 @@ public interface TeamClient {
     UserProfile login(PlayerLogin playerLogin);
 
     /**
+     * Called when a player logs out.
+     */
+    void logout(PlayerLogout playerLogout);
+
+    /**
      * Called whenever a map is loaded.
      * Returns the map id.
      */
@@ -35,6 +40,10 @@ public interface TeamClient {
     void finishMatch(MatchFinishPacket matchFinishPacket);
 
     void destroyWool(DestroyWoolRequest destroyWoolRequest);
+
+    void pickupWool(WoolPickupRequest woolPickupRequest);
+
+    void placeWool(WoolPlacementRequest woolPlacementRequest);
     
     RankList retrieveRanks();
 

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/http/HttpClient.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/http/HttpClient.java
@@ -100,6 +100,20 @@ public class HttpClient implements TeamClient {
     }
 
     @Override
+    public void logout(PlayerLogout playerLogout) {
+        try {
+            HttpResponse<JsonNode> jsonResponse = Unirest.post(config.getBaseUrl() + "/mc/player/logout")
+                    .header("x-access-token", config.getAuthToken())
+                    .header("accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .body(playerLogout)
+                    .asJson();
+        } catch (UnirestException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
     public MapLoadResponse loadmap(Map map) {
         try {
             HttpResponse<MapLoadResponse> mapLoadResponse = Unirest.post(config.getBaseUrl() + "/mc/map/load")
@@ -167,6 +181,34 @@ public class HttpClient implements TeamClient {
                     .header("accept", "application/json")
                     .header("Content-Type", "application/json")
                     .body(destroyWoolRequest)
+                    .asJson();
+        } catch (UnirestException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void pickupWool(WoolPickupRequest woolPickupRequest) {
+        try {
+            Unirest.post(config.getBaseUrl() + "/mc/match/pickup_wool")
+                    .header("x-access-token", config.getAuthToken())
+                    .header("accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .body(woolPickupRequest)
+                    .asJson();
+        } catch (UnirestException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void placeWool(WoolPlacementRequest woolPlacementRequest) {
+        try {
+            Unirest.post(config.getBaseUrl() + "/mc/match/place_wool")
+                    .header("x-access-token", config.getAuthToken())
+                    .header("accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .body(woolPlacementRequest)
                     .asJson();
         } catch (UnirestException e) {
             e.printStackTrace();

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/offline/OfflineClient.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/offline/OfflineClient.java
@@ -26,8 +26,13 @@ public class OfflineClient implements TeamClient {
     @Override
     public UserProfile login(PlayerLogin playerLogin) {
         return new UserProfile(new ObjectId(), playerLogin.getName(), playerLogin.getName().toLowerCase(),
-                playerLogin.getUuid(), new Date().getTime(), new Date().getTime(), Collections.singletonList(playerLogin.getIp()), new ArrayList<>(), new ArrayList<>(),
-                0, 0, 0, 0, 0, new ArrayList<>(), new ArrayList<>(), false);
+                playerLogin.getUuid(), new Date().getTime(), new Date().getTime(), 0, Collections.singletonList(playerLogin.getIp()), new ArrayList<>(), new ArrayList<>(),
+                0, 0, 0, 0, 0, 0, 0, new ArrayList<>(), new ArrayList<>(), false);
+    }
+
+    @Override
+    public void logout(PlayerLogout playerLogout) {
+
     }
 
     @Override
@@ -52,6 +57,16 @@ public class OfflineClient implements TeamClient {
 
     @Override
     public void destroyWool(DestroyWoolRequest destroyWoolRequest) {
+
+    }
+
+    @Override
+    public void pickupWool(WoolPickupRequest woolPickupRequest) {
+
+    }
+
+    @Override
+    public void placeWool(WoolPlacementRequest woolPlacementRequest) {
 
     }
 

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/PlayerLogout.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/PlayerLogout.java
@@ -1,0 +1,10 @@
+package network.warzone.warzoneapi.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class PlayerLogout {
+    @Getter private final String name;
+    @Getter private final String uuid;
+}

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/UserProfile.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/UserProfile.java
@@ -18,7 +18,9 @@ public class UserProfile {
     public static final int XP_PER_KILL = 2,
                             XP_PER_WIN = 10,
                             XP_PER_LOSS = 5,
-                            XP_PER_WOOL_BREAK = 3;
+                            XP_PER_WOOL_BREAK = 3,
+                            XP_PER_WOOL_PICKUP = 3,
+                            XP_PER_WOOL_PLACEMENT = 12;
 
     @SerializedName("_id")
     private ObjectId id;
@@ -28,6 +30,7 @@ public class UserProfile {
     private String uuid;
     private long initialJoinDate;
     private long lastOnlineDate;
+    private long totalPlaytime;
 
     private List<String> ips;
     private List<String> ranks;
@@ -37,6 +40,8 @@ public class UserProfile {
     private int kills = 0;
     private int deaths = 0;
     private int wool_destroys = 0;
+    private int wool_pickups = 0;
+    private int wool_placements = 0;
     private List<String> matches;
 
     private List<Punishment> punishments;
@@ -96,8 +101,16 @@ public class UserProfile {
         wool_destroys++;
     }
 
+    public void addWoolPickup() {
+        wool_pickups++;
+    }
+
+    public void addWoolPlacement() {
+        wool_placements++;
+    }
+
     public int getXP() {
-        return (getWins() * XP_PER_WIN) + (getLosses() * XP_PER_LOSS) + (getWool_destroys() * XP_PER_WOOL_BREAK) + (getKills() * XP_PER_KILL);
+        return (getWins() * XP_PER_WIN) + (getLosses() * XP_PER_LOSS) + (getWool_destroys() * XP_PER_WOOL_BREAK) + (getWool_pickups() * XP_PER_WOOL_PICKUP) + (getWool_placements() * XP_PER_WOOL_PLACEMENT) + (getKills() * XP_PER_KILL);
     }
 
     public int getLevel() {

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/WoolPickupRequest.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/WoolPickupRequest.java
@@ -1,0 +1,11 @@
+package network.warzone.warzoneapi.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@AllArgsConstructor
+public class WoolPickupRequest {
+    @Getter private UUID uuid; //player uuid
+}

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/WoolPlacementRequest.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/WoolPlacementRequest.java
@@ -1,0 +1,11 @@
+package network.warzone.warzoneapi.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@AllArgsConstructor
+public class WoolPlacementRequest {
+    @Getter private UUID uuid; //player uuid
+}


### PR DESCRIPTION
Playtime can be viewed by the /stats command

Tested, works 100% without errors (TGM and its API). Levels and XP are the same on the API as shown in-game.

I also added XP for wool pickups and placements, since it's an objective. Since the average DTW map on Warzone gives you 3 XP per wool, and there are 10 wools, I made wool pickups give you 3 XP and placements 12 XP, so two wools per CTW map would give you in total 30 XP, like DTW maps.