### PR TITLE
Adds First Blood Option

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
@@ -158,8 +158,10 @@ public class ApiManager implements Listener {
         boolean firstBlood = false;
         if(currentMatch != null) {
             firstBlooder = currentMatch.getFirstBlood();
-            if(currentMatch.getModule(FirstBloodModule.class).isEnabled() && (firstBlooder == null || firstBlooder.equals(module.getKiller()))) {
+            FirstBloodModule firstBloodController = currentMatch.getModule(FirstBloodModule.class);
+            if(firstBloodController.isEnabled() && (firstBlooder == null || firstBlooder.equals(module.getKiller())) && firstBloodController.isRelevant()) {
                 firstBlood = true;
+                firstBloodController.setRelevant(false);
             }
         }
         PlayerContext killed = TGM.get().getPlayerManager().getPlayerContext(module.getPlayer());

--- a/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
@@ -158,7 +158,6 @@ public class ApiManager implements Listener {
         boolean firstBlood = false;
         if(currentMatch != null) {
             firstBlooder = currentMatch.getFirstBlood();
-            Bukkit.broadcastMessage("" + currentMatch.getModule(FirstBloodModule.class).isEnabled());
             if(currentMatch.getModule(FirstBloodModule.class).isEnabled() && (firstBlooder == null || firstBlooder.equals(module.getKiller()))) {
                 firstBlood = true;
             }

--- a/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
@@ -9,6 +9,7 @@ import network.warzone.tgm.match.MatchLoadEvent;
 import network.warzone.tgm.match.MatchResultEvent;
 import network.warzone.tgm.modules.ChatModule;
 import network.warzone.tgm.modules.DeathModule;
+import network.warzone.tgm.modules.FirstBloodModule;
 import network.warzone.tgm.modules.StatsModule;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
@@ -157,7 +158,8 @@ public class ApiManager implements Listener {
         boolean firstBlood = false;
         if(currentMatch != null) {
             firstBlooder = currentMatch.getFirstBlood();
-            if(firstBlooder == null || firstBlooder.equals(module.getKiller())) {
+            Bukkit.broadcastMessage("" + currentMatch.getModule(FirstBloodModule.class).isEnabled());
+            if(currentMatch.getModule(FirstBloodModule.class).isEnabled() && (firstBlooder == null || firstBlooder.equals(module.getKiller()))) {
                 firstBlood = true;
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -670,6 +670,8 @@ public class CycleCommands {
                 sender.sendMessage(ChatColor.DARK_AQUA + "   Deaths: " + ChatColor.RED + up.getDeaths());
                 sender.sendMessage(ChatColor.DARK_AQUA + "   K/D: " + ChatColor.AQUA + up.getKDR());
                 sender.sendMessage("");
+                sender.sendMessage(ChatColor.DARK_AQUA + "   First Bloods: " + ChatColor.GREEN + up.getFirstBloods());
+                sender.sendMessage("");
                 sender.sendMessage(ChatColor.DARK_AQUA + "   Wins: " + ChatColor.GREEN + up.getWins());
                 sender.sendMessage(ChatColor.DARK_AQUA + "   Losses: " + ChatColor.RED + up.getLosses());
                 sender.sendMessage(ChatColor.DARK_AQUA + "   W/L: " + ChatColor.AQUA + up.getWLR());
@@ -687,6 +689,8 @@ public class CycleCommands {
         sender.sendMessage(ChatColor.DARK_AQUA + "   Kills: " + ChatColor.GREEN + targetUser.getUserProfile().getKills());
         sender.sendMessage(ChatColor.DARK_AQUA + "   Deaths: " + ChatColor.RED + targetUser.getUserProfile().getDeaths());
         sender.sendMessage(ChatColor.DARK_AQUA + "   K/D: " + ChatColor.AQUA + targetUser.getUserProfile().getKDR());
+        sender.sendMessage("");
+        sender.sendMessage(ChatColor.DARK_AQUA + "   First Bloods: " + ChatColor.GREEN + targetUser.getUserProfile().getFirstBloods());
         sender.sendMessage("");
         sender.sendMessage(ChatColor.DARK_AQUA + "   Wins: " + ChatColor.GREEN + targetUser.getUserProfile().getWins());
         sender.sendMessage(ChatColor.DARK_AQUA + "   Losses: " + ChatColor.RED + targetUser.getUserProfile().getLosses());

--- a/TGM/src/main/java/network/warzone/tgm/match/Match.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/Match.java
@@ -7,6 +7,7 @@ import network.warzone.tgm.TGM;
 import network.warzone.tgm.map.MapContainer;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 
@@ -23,7 +24,7 @@ public class Match {
     private final World world;
     private final MapContainer mapContainer;
     @Setter private MatchStatus matchStatus = MatchStatus.PRE;
-    @Setter private UUID firstBlood;
+    @Setter private Player firstBlood;
     private long startedTime;
     private long finishedTime;
 
@@ -32,6 +33,7 @@ public class Match {
         this.matchManifest = matchManifest;
         this.world = world;
         this.mapContainer = mapContainer;
+        this.firstBlood = null;
     }
 
     /**

--- a/TGM/src/main/java/network/warzone/tgm/match/Match.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/Match.java
@@ -23,7 +23,7 @@ public class Match {
     private final World world;
     private final MapContainer mapContainer;
     @Setter private MatchStatus matchStatus = MatchStatus.PRE;
-
+    @Setter private UUID firstBlood;
     private long startedTime;
     private long finishedTime;
 

--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
@@ -74,6 +74,7 @@ public abstract class MatchManifest {
         modules.add(new StatsModule());
         modules.add(new PortalLoaderModule());
         modules.add(new WorldBorderModule());
+        modules.add(new FirstBloodModule());
         return modules;
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/DeathModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/DeathModule.java
@@ -13,8 +13,6 @@ import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
 import network.warzone.tgm.util.itemstack.ItemFactory;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Sound;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;

--- a/TGM/src/main/java/network/warzone/tgm/modules/DeathModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/DeathModule.java
@@ -10,9 +10,7 @@ import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
 import network.warzone.tgm.util.itemstack.ItemFactory;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
+import org.bukkit.*;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -100,7 +98,16 @@ public class DeathModule extends MatchModule implements Listener {
     @EventHandler
     public void onDeath(PlayerDeathEvent event) {
         DeathModule module = getPlayer(event.getEntity());
-
+        Match currentMatch = TGM.get().getMatchManager().getMatch();
+        if(currentMatch.getFirstBlood().toString().length() > 0 && module.getKiller() != null) {
+            String message = killerTeam.getColor() + module.getKillerName() + ChatColor.GRAY + " dealt" + ChatColor.GOLD + ChatColor.BOLD + " FIRST BLOOD!";
+            for(Player player : Bukkit.getOnlinePlayers()) {
+                Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
+                player.getPlayer().sendMessage(message);
+                player.playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1000, 2);
+            }
+            currentMatch.setFirstBlood(module.getKiller().getUniqueId());
+        }
         new TGMPlayerDeathEvent(module.getPlayer(), module.getKiller(), module.getCause(), module.getItem()).callEvent();
 
         Bukkit.getScheduler().runTaskLater(TGM.get(), () -> event.getEntity().spigot().respawn(), 1L);

--- a/TGM/src/main/java/network/warzone/tgm/modules/DeathModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/DeathModule.java
@@ -10,7 +10,11 @@ import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
 import network.warzone.tgm.util.itemstack.ItemFactory;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -99,14 +103,19 @@ public class DeathModule extends MatchModule implements Listener {
     public void onDeath(PlayerDeathEvent event) {
         DeathModule module = getPlayer(event.getEntity());
         Match currentMatch = TGM.get().getMatchManager().getMatch();
-        if(currentMatch.getFirstBlood().toString().length() > 0 && module.getKiller() != null) {
-            String message = killerTeam.getColor() + module.getKillerName() + ChatColor.GRAY + " dealt" + ChatColor.GOLD + ChatColor.BOLD + " FIRST BLOOD!";
-            for(Player player : Bukkit.getOnlinePlayers()) {
-                Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
-                player.getPlayer().sendMessage(message);
-                player.playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1000, 2);
+        if(currentMatch != null) {
+            if(currentMatch.getFirstBlood() == null && module.getKiller() != null) {
+                currentMatch.setFirstBlood(module.getKiller());
+                String msg = "";
+                if (!module.getPlayerTeam().isSpectator() && module.getKiller() != null && module.getKillerTeam() != null) {
+                    msg = module.getKillerTeam().getColor() + module.getKillerName() + ChatColor.GRAY + " has drawn" + ChatColor.GOLD + ChatColor.BOLD + " FIRST BLOOD!";
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
+                        player.getPlayer().sendMessage(msg);
+                        player.playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1000, 2);
+                    }
+                }
             }
-            currentMatch.setFirstBlood(module.getKiller().getUniqueId());
         }
         new TGMPlayerDeathEvent(module.getPlayer(), module.getKiller(), module.getCause(), module.getItem()).callEvent();
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/FirstBloodModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/FirstBloodModule.java
@@ -1,0 +1,63 @@
+package network.warzone.tgm.modules;
+
+import com.google.gson.JsonObject;
+import lombok.Getter;
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.map.MapContainer;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.match.MatchLoadEvent;
+import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+@Getter
+public class FirstBloodModule extends MatchModule implements Listener {
+    private boolean enabled;
+    private String msg;
+    private Match currentMatch = null;
+    private DeathModule deathModule = null;
+
+    @Override
+    public void load(Match match) {
+        currentMatch = match;
+        deathModule = currentMatch.getModule(DeathModule.class);
+        JsonObject mapData = match.getMapContainer().getMapInfo().getJsonObject();
+        if(mapData.has("firstBlood")) {
+            JsonObject firstBloodOpts = mapData.get("firstBlood").getAsJsonObject();
+            enabled = false;
+            if(firstBloodOpts.has("enabled")) enabled = firstBloodOpts.get("enabled").getAsBoolean();
+            msg = "%killer% &7has drew &6&lFIRST BLOOD!";
+            if(firstBloodOpts.has("message")) msg = firstBloodOpts.get("message").getAsString();
+        }
+    }
+
+    @EventHandler
+    public void onKill(TGMPlayerDeathEvent event) {
+        DeathModule module = deathModule.getPlayer(event.getVictim());
+        if(module == null || !enabled) return;
+        if(currentMatch != null) {
+            if(currentMatch.getFirstBlood() == null && module.getKiller() != null && module.getKillerTeam() != null && module.getPlayerTeam() != null) {
+                currentMatch.setFirstBlood(module.getKiller());
+                if (!module.getPlayerTeam().isSpectator() && !module.getKillerTeam().isSpectator()) {
+                    String realMsg = msg;
+                    realMsg = ChatColor.translateAlternateColorCodes('&', realMsg);
+                    realMsg = realMsg.replaceAll("%killer%", module.getKillerTeam().getColor() + module.getKillerName());
+                    realMsg = realMsg.replaceAll("%victim%", module.getPlayerTeam().getColor() + module.getPlayerName());
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
+                        player.getPlayer().sendMessage(realMsg);
+                        player.playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1000, 2);
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/FirstBloodModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/FirstBloodModule.java
@@ -2,11 +2,7 @@ package network.warzone.tgm.modules;
 
 import com.google.gson.JsonObject;
 import lombok.Getter;
-import network.warzone.tgm.TGM;
-import network.warzone.tgm.map.MapContainer;
-import network.warzone.tgm.match.Match;
-import network.warzone.tgm.match.MatchLoadEvent;
-import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.match.*;
 import network.warzone.tgm.player.event.TGMPlayerDeathEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -15,9 +11,8 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
 
-@Getter
+@ModuleData(load = ModuleLoadTime.EARLIER) @Getter
 public class FirstBloodModule extends MatchModule implements Listener {
     private boolean enabled;
     private String msg;
@@ -42,19 +37,17 @@ public class FirstBloodModule extends MatchModule implements Listener {
     public void onKill(TGMPlayerDeathEvent event) {
         DeathModule module = deathModule.getPlayer(event.getVictim());
         if(module == null || !enabled) return;
-        if(currentMatch != null) {
-            if(currentMatch.getFirstBlood() == null && module.getKiller() != null && module.getKillerTeam() != null && module.getPlayerTeam() != null) {
-                currentMatch.setFirstBlood(module.getKiller());
-                if (!module.getPlayerTeam().isSpectator() && !module.getKillerTeam().isSpectator()) {
-                    String realMsg = msg;
-                    realMsg = ChatColor.translateAlternateColorCodes('&', realMsg);
-                    realMsg = realMsg.replaceAll("%killer%", module.getKillerTeam().getColor() + module.getKillerName());
-                    realMsg = realMsg.replaceAll("%victim%", module.getPlayerTeam().getColor() + module.getPlayerName());
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
-                        player.getPlayer().sendMessage(realMsg);
-                        player.playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1000, 2);
-                    }
+        if(currentMatch != null && currentMatch.getFirstBlood() == null && module.getKiller() != null && module.getKillerTeam() != null && module.getPlayerTeam() != null) {
+            currentMatch.setFirstBlood(module.getKiller());
+            if (!module.getPlayerTeam().isSpectator() && !module.getKillerTeam().isSpectator()) {
+                String realMsg = msg;
+                realMsg = ChatColor.translateAlternateColorCodes('&', realMsg);
+                realMsg = realMsg.replaceAll("%killer%", module.getKillerTeam().getColor() + module.getKillerName());
+                realMsg = realMsg.replaceAll("%victim%", module.getPlayerTeam().getColor() + module.getPlayerName());
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    Location location = player.getLocation().clone().add(0.0, 100.0, 0.0);
+                    player.getPlayer().sendMessage(realMsg);
+                    player.playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1000, 2);
                 }
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -139,7 +139,7 @@ public class InfectionModule extends MatchModule implements Listener {
 
         ApiManager api = TGM.get().getApiManager();
         Death death = new Death(playerContext.getUserProfile().getId().toString(), killerId, playerItem, killerItem,
-                api.getMatchInProgress().getMap(), api.getMatchInProgress().getId());
+                false, api.getMatchInProgress().getMap(), api.getMatchInProgress().getId());
 
         Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> TGM.get().getTeamClient().addKill(death));
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -101,8 +101,13 @@ public class InfectionModule extends MatchModule implements Listener {
         MatchTeam humans = teamManager.getTeamById("humans");
         MatchTeam infected = teamManager.getTeamById("infected");
         DeathModule deadModule = null;
-        deadModule = deathModuleController.getPlayer((Player) event.getEntity());
-        firstBloodController.onKill(new TGMPlayerDeathEvent(deadModule.getPlayer(), deadModule.getKiller(), deadModule.getCause(), deadModule.getItem()));
+        boolean wasFirstBlood = false;
+        if(firstBloodController.isRelevant()) {
+            deadModule = deathModuleController.getPlayer((Player) event.getEntity());
+            wasFirstBlood = true;
+            firstBloodController.onKill(new TGMPlayerDeathEvent(deadModule.getPlayer(), deadModule.getKiller(), deadModule.getCause(), deadModule.getItem()));
+            firstBloodController.setRelevant(false);
+        }
         if (humans.containsPlayer(player)) {
             if (event.getDamager() instanceof Player) {
                 broadcastMessage(String.format("%s%s &7has been infected by %s%s",
@@ -148,7 +153,7 @@ public class InfectionModule extends MatchModule implements Listener {
 
         ApiManager api = TGM.get().getApiManager();
         Death death = new Death(playerContext.getUserProfile().getId().toString(), killerId, playerItem, killerItem,
-                firstBloodController.isEnabled(), api.getMatchInProgress().getMap(), api.getMatchInProgress().getId());
+                wasFirstBlood, api.getMatchInProgress().getMap(), api.getMatchInProgress().getId());
 
         Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> TGM.get().getTeamClient().addKill(death));
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -7,7 +7,6 @@ import network.warzone.tgm.api.ApiManager;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
 import network.warzone.tgm.match.MatchStatus;
-import network.warzone.tgm.modules.DeathMessageModule;
 import network.warzone.tgm.modules.DeathModule;
 import network.warzone.tgm.modules.FirstBloodModule;
 import network.warzone.tgm.modules.team.MatchTeam;
@@ -23,7 +22,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -150,7 +148,7 @@ public class InfectionModule extends MatchModule implements Listener {
 
         ApiManager api = TGM.get().getApiManager();
         Death death = new Death(playerContext.getUserProfile().getId().toString(), killerId, playerItem, killerItem,
-                false, api.getMatchInProgress().getMap(), api.getMatchInProgress().getId());
+                firstBloodController.isEnabled(), api.getMatchInProgress().getMap(), api.getMatchInProgress().getId());
 
         Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> TGM.get().getTeamClient().addKill(death));
     }

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/offline/OfflineClient.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/client/offline/OfflineClient.java
@@ -27,7 +27,7 @@ public class OfflineClient implements TeamClient {
     public UserProfile login(PlayerLogin playerLogin) {
         return new UserProfile(new ObjectId(), playerLogin.getName(), playerLogin.getName().toLowerCase(),
                 playerLogin.getUuid(), new Date().getTime(), new Date().getTime(), Collections.singletonList(playerLogin.getIp()), new ArrayList<>(), new ArrayList<>(),
-                0, 0, 0, 0, 0, new ArrayList<>(), new ArrayList<>(), false);
+                0, 0, 0, 0, 0, 0, new ArrayList<>(), new ArrayList<>(), false);
     }
 
     @Override

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/Death.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/Death.java
@@ -10,6 +10,7 @@ public class Death {
 
     @Getter private String playerItem;
     @Getter private String killerItem;
+    @Getter private boolean firstBlood;
 
     @Getter private String map; //id
     @Getter private String match; //id

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/UserProfile.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/UserProfile.java
@@ -36,6 +36,7 @@ public class UserProfile {
     private int losses = 0;
     private int kills = 0;
     private int deaths = 0;
+    private int firstBloods = 0;
     private int wool_destroys = 0;
     private List<String> matches;
 
@@ -87,6 +88,8 @@ public class UserProfile {
     public void addDeath() {
         deaths++;
     }
+
+    public void addFirstBlood() { firstBloods++; }
 
     public void addLoss() {
         losses++;


### PR DESCRIPTION
Proposition for #145 
Adds First Bloods. Looking through the conversation of #145 , making it Map specific appeared to be a good idea, so I made it an option in the `map.json`

Syntax is as follows:
![syntax](https://vgy.me/Wz8AH9.png)

The entire field is optional, so not adding a `firstBlood` key is perfectly alright (it will obviously default to false). If the field is added, the `message` key in the firstBlood object is also optional. It will default to a default message for firstBlood in that case.

Only difference is instead of %player%, it is `%killer%` and `%victim%` that can be used.
My example

![example](https://vgy.me/ZyIAZT.png)

I also added it to the API to the MinecraftUser Schema. Hence, it can be seen in /stats:
![stats](https://vgy.me/a8LJyd.png)

Here is the PR for modifying the MinecraftUser Schema for the API:
https://github.com/WarzoneMC/api/pull/20

