### PR TITLE
"New" Gamemode - Overtime for DTM

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -197,7 +197,7 @@ public class CycleCommands {
     @CommandPermissions({"tgm.cycle"})
     public static void cycle(CommandContext cmd, CommandSender sender) {
         MatchStatus matchStatus = TGM.get().getMatchManager().getMatch().getMatchStatus();
-        if (matchStatus != MatchStatus.MID) {
+        if (!(matchStatus == MatchStatus.MID || matchStatus == MatchStatus.OVERTIME)) {
             int time = CycleCountdown.START_TIME;
             if (cmd.argsLength() > 0) {
                 try {
@@ -237,7 +237,7 @@ public class CycleCommands {
     @CommandPermissions({"tgm.end"})
     public static void end(CommandContext cmd, CommandSender sender) {
         MatchStatus matchStatus = TGM.get().getMatchManager().getMatch().getMatchStatus();
-        if (matchStatus == MatchStatus.MID) {
+        if (matchStatus == MatchStatus.MID || matchStatus == MatchStatus.OVERTIME) {
             if (cmd.argsLength() > 0) {
                 MatchTeam matchTeam = TGM.get().getModule(TeamManagerModule.class).getTeamFromInput(cmd.getJoinedStrings(0));
                 if (matchTeam == null) {
@@ -310,8 +310,11 @@ public class CycleCommands {
         GameType gameType = matchManager.getMatch().getMapContainer().getMapInfo().getGametype();
         MatchStatus matchStatus = matchManager.getMatch().getMatchStatus();
         if (cmd.argsLength() == 0) {
-            if (gameType.equals(GameType.Blitz) || gameType.equals(GameType.FFA) && TGM.get().getModule(FFAModule.class).isBlitzMode()) {
-                if (!matchStatus.equals(MatchStatus.PRE)) {
+            if (gameType.equals(GameType.Blitz) || gameType.equals(GameType.FFA) && TGM.get().getModule(FFAModule.class).isBlitzMode() || matchStatus == MatchStatus.OVERTIME) {
+                if(matchStatus == MatchStatus.OVERTIME) {
+                    sender.sendMessage(ChatColor.RED + "You can't pick a team after the match goes to overtime.");
+                    return;
+                } else if (!matchStatus.equals(MatchStatus.PRE)) {
                     sender.sendMessage(ChatColor.RED + "You can't pick a team after the match starts in this gamemode.");
                     return;
                 }
@@ -350,7 +353,7 @@ public class CycleCommands {
                         attemptJoinTeam((Player) sender, matchTeam, false);
                         return;
                     }
-                } else if (matchStatus.equals(MatchStatus.MID)) {
+                } else if (matchStatus.equals(MatchStatus.MID) || matchStatus.equals(MatchStatus.OVERTIME)) {
                     if (!matchTeam.isSpectator()) {
                         sender.sendMessage(ChatColor.RED + "You can't pick a team after the match starts in this gamemode.");
                         return;

--- a/TGM/src/main/java/network/warzone/tgm/match/MatchStatus.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchStatus.java
@@ -3,5 +3,6 @@ package network.warzone.tgm.match;
 public enum MatchStatus {
     PRE,
     MID,
+    OVERTIME,
     POST
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpawnPointHandlerModule.java
@@ -33,7 +33,7 @@ public class SpawnPointHandlerModule extends MatchModule implements Listener {
 
     @EventHandler
     public void onTeamChange(TeamChangeEvent event) {
-        if (TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.MID) {
+        if (TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.MID || TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.OVERTIME) {
             spawnPlayer(event.getPlayerContext(), event.getTeam(), true);
         }
         //player is joining the server

--- a/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/SpectatorModule.java
@@ -174,7 +174,7 @@ public class SpectatorModule extends MatchModule implements Listener {
      */
     public boolean isSpectating(Player player) {
         MatchStatus matchStatus = TGM.get().getMatchManager().getMatch().getMatchStatus();
-        return matchStatus != MatchStatus.MID || spectators.containsPlayer(player);
+        return !(matchStatus == MatchStatus.MID || matchStatus == MatchStatus.OVERTIME) || spectators.containsPlayer(player);
     }
 
     @EventHandler

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -18,10 +18,12 @@ import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.modules.team.TeamUpdateEvent;
 import network.warzone.tgm.modules.time.TimeModule;
-import network.warzone.tgm.player.PlayerManager;
 import network.warzone.tgm.player.event.PlayerXPEvent;
 import network.warzone.tgm.user.PlayerContext;
-import network.warzone.tgm.util.*;
+import network.warzone.tgm.util.ColorConverter;
+import network.warzone.tgm.util.FireworkUtil;
+import network.warzone.tgm.util.Parser;
+import network.warzone.tgm.util.TitleAPI;
 import network.warzone.warzoneapi.models.DestroyWoolRequest;
 import network.warzone.warzoneapi.models.UserProfile;
 import org.apache.commons.lang3.StringUtils;
@@ -34,10 +36,11 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
@@ -162,7 +165,7 @@ public class DTMModule extends MatchModule implements Listener {
     }
 
     private void checkOvertimeOver() {
-        if(!(TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.OVERTIME)) return;
+        if(TGM.get().getMatchManager().getMatch().getMatchStatus() != MatchStatus.OVERTIME) return;
         int winnerCount = 0;
         MatchTeam winner = null;
         for(MatchTeam team : teamManager.getTeams()) {
@@ -192,8 +195,8 @@ public class DTMModule extends MatchModule implements Listener {
         if (!(event.getEntity() instanceof Player)) return;
         Player player = (Player) event.getEntity();
 
-        if (!(TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.OVERTIME)
-                || teamManager.getTeam(player).isSpectator() || player.getHealth() - event.getFinalDamage() >= 0.5) return;
+        if (TGM.get().getMatchManager().getMatch().getMatchStatus() != MatchStatus.OVERTIME ||
+                teamManager.getTeam(player).isSpectator() || player.getHealth() - event.getFinalDamage() >= 0.5) return;
 
 
         for(String id : overtime.getNoRespawn()) {

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMOvertime.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMOvertime.java
@@ -3,7 +3,6 @@ package network.warzone.tgm.modules.dtm;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import network.warzone.tgm.modules.team.MatchTeam;
 
 import java.util.List;
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMOvertime.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMOvertime.java
@@ -1,0 +1,16 @@
+package network.warzone.tgm.modules.dtm;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import network.warzone.tgm.modules.team.MatchTeam;
+
+import java.util.List;
+
+@AllArgsConstructor @Getter
+public class DTMOvertime {
+    @Setter private boolean overtimeEnabled;
+    private List<String> noRespawn;
+    private String respawnTitle;
+    private String respawnSubtitle;
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/EnterFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/EnterFilterType.java
@@ -1,5 +1,7 @@
 package network.warzone.tgm.modules.filter.type;
 
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.match.MatchStatus;
 import network.warzone.tgm.modules.filter.FilterResult;
 import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
 import network.warzone.tgm.modules.region.Region;
@@ -26,6 +28,7 @@ public class EnterFilterType implements FilterType, Listener {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
+                        if(TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.OVERTIME || TGM.get().getMatchManager().getMatch().getMatchStatus() == MatchStatus.POST) filterResult = FilterResult.ALLOW;
                         if (filterResult == FilterResult.DENY) {
                             event.setCancelled(true);
                             event.getPlayer().sendMessage(message);

--- a/TGM/src/main/java/network/warzone/tgm/modules/monument/Monument.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/monument/Monument.java
@@ -39,7 +39,8 @@ public class Monument implements Listener {
         if (region.contains(event.getBlock().getLocation())) {
             if (materials == null || materials.contains(event.getBlock().getType())) {
                 if (canDamage(event.getPlayer())) {
-                    if (TGM.get().getMatchManager().getMatch().getMatchStatus().equals(MatchStatus.MID)) {
+                    if (TGM.get().getMatchManager().getMatch().getMatchStatus().equals(MatchStatus.MID)
+                            || TGM.get().getMatchManager().getMatch().getMatchStatus().equals(MatchStatus.OVERTIME)) {
                         event.setCancelled(false); //override filters
                         event.getBlock().getDrops().clear();
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/time/TimeModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/time/TimeModule.java
@@ -91,7 +91,7 @@ public class TimeModule extends MatchModule {
 
     public double getTimeElapsed() {
         MatchStatus matchStatus = TGM.get().getMatchManager().getMatch().getMatchStatus();
-        if (matchStatus == MatchStatus.MID) {
+        if (matchStatus == MatchStatus.MID || matchStatus == MatchStatus.OVERTIME) {
             return (double) ((System.currentTimeMillis() - startedTimeStamp) / 1000);
         } else if (matchStatus == MatchStatus.POST) {
             return (double) ((endedTimeStamp - startedTimeStamp) / 1000);


### PR DESCRIPTION
Proposition for #216 

Adds an "overtime" mode to Destroy the Monument/Wool. When your wool/monument is destroyed, you will no longer respawn.

It can be activated by the `map.json` for maps of gametype DTM, using the `overtime` key in the `dtm` object. It is optional, so you do not have to add it. Neither are the `respawn_title` and `respawn_subtitle` fields.

![config](https://vgy.me/8BLWhh.png)

Here's just a GIF from when your wool is broken.
https://vgy.me/mOzzos.gif