### PR TITLE
Ability to change store URL and server name on tablist

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -712,7 +712,7 @@ public class CycleCommands {
 
         if (!autoJoin) {
             if (!player.hasPermission("tgm.pickteam")) {
-                player.sendMessage(ChatColor.LIGHT_PURPLE + "Only premium users can pick their team! Purchase a rank at https://tgmwarzone.tebex.io/");
+                player.sendMessage(ChatColor.LIGHT_PURPLE + "Only premium users can pick their team!\nPurchase a rank at " + TGM.get().getConfig().getString("server.store"));
                 return;
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/TabListModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/TabListModule.java
@@ -53,7 +53,7 @@ public class TabListModule extends MatchModule implements Listener {
 
         String header = ChatColor.WHITE + ChatColor.BOLD.toString() + TGM.get().getMatchManager().getMatch().getMapContainer().getMapInfo().getGametype().toString() +
                         ChatColor.DARK_GRAY + " - " + timeColor + Strings.formatTime(TGM.get().getMatchManager().getMatch().getModule(TimeModule.class).getTimeElapsed()) +
-                        ChatColor.DARK_GRAY + " - " + ChatColor.WHITE + ChatColor.BOLD.toString() + "WARZONE";
+                        ChatColor.DARK_GRAY + " - " + ChatColor.WHITE + ChatColor.BOLD.toString() + net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', TGM.get().getConfig().getString("server.tablist-name") == null ? "&f&lWARZONE" : TGM.get().getConfig().getString("server.tablist-name"));
 
         String footer = "";
         for (MatchTeam matchTeam : teamManagerModule.getTeams()) {

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -16,3 +16,4 @@ server:
   name: "Warzone"
   id: "warzone"
   store: "https://tgmwarzone.tebex.io/"
+  tablist-name: "&f&lWARZONE"

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -15,4 +15,4 @@ map:
 server:
   name: "Warzone"
   id: "warzone"
-  
+  store: "https://tgmwarzone.tebex.io/"


### PR DESCRIPTION
This pull request adds the ability for the user to change the store URL located in `config.yml`. By default, it is the Warzone server store URL.

Edit:
Also adds the ability to change the server name on tab because I forgot to do things to put that in a new PR.