### PR TITLE
Change staff chat colour to green

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -249,7 +249,7 @@ public class PunishCommands {
         } else {
             prefix = "";
         }
-        String result = ChatColor.DARK_RED + "[STAFF] " + prefix + ChatColor.GREEN + sender.getName() + ": " + ChatColor.LIGHT_PURPLE + cmd.getRemainingString(0);
+        String result = ChatColor.DARK_RED + "[STAFF] " + prefix + ChatColor.RESET + sender.getName() + ": " + ChatColor.GREEN + cmd.getRemainingString(0);
         for (Player player : Bukkit.getOnlinePlayers()) {
             if (player.hasPermission("tgm.staffchat")) player.sendMessage(result);
         }


### PR DESCRIPTION
This makes staff chat easier to see and read next to all of the white and grey chat. I edited the wrong colour in #462.