### PR TITLE
Instant world loading

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
@@ -111,6 +111,11 @@ public class JoinManager implements Listener {
         if (playerContext.getUserProfile().isNew()) joinMsg += ChatColor.LIGHT_PURPLE + " [NEW]";
         event.setJoinMessage(joinMsg);
     }
+    
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onWorldInit(WorldInitEvent e) {
+        e.getWorld().setKeepSpawnInMemory(false);
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onCycle(MatchPostLoadEvent event) {


### PR DESCRIPTION
This PR stops the server keeping spawn chunks for each map in memory, resulting in faster (instant) map cycling