### PR TITLE
Let map developers specify a command that is run on match start

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
@@ -75,6 +75,7 @@ public abstract class MatchManifest {
         modules.add(new PortalLoaderModule());
         modules.add(new WorldBorderModule());
         modules.add(new KnockbackModule());
+        modules.add(new MapCommandsModule());
         return modules;
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/MapCommandsModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/MapCommandsModule.java
@@ -1,0 +1,25 @@
+package network.warzone.tgm.modules;
+
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.match.MatchModule;
+
+public class MapCommandsModule extends MatchModule {
+    Match match;
+
+    String startCommand;
+
+    @Override
+    public void enable() {
+        if (this.startCommand != null)
+            TGM.get().getServer().dispatchCommand(TGM.get().getServer().getConsoleSender(), this.startCommand);
+    }
+
+    @Override
+    public void load(Match match) {
+        this.match = match;
+
+        if (match.getMapContainer().getMapInfo().getJsonObject().has("startCommand"))
+            this.startCommand = match.getMapContainer().getMapInfo().getJsonObject().get("startCommand").getAsString();
+    }
+}


### PR DESCRIPTION
map.json can have a "startCommand" property that will execute the value as console when the match starts. You should not include a slash (/) in the startCommand value.

Closes #487