### PR TITLE
Add Actions to KillstreakModule

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/EffectKillstreakAction.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/EffectKillstreakAction.java
@@ -1,0 +1,18 @@
+package network.warzone.tgm.modules.killstreak;
+
+import lombok.AllArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+
+import java.util.Set;
+
+@AllArgsConstructor
+class EffectKillstreakAction implements KillstreakAction {
+    private Set<PotionEffect> potionEffects;
+    @Override
+    public void apply(Player killer) {
+        for(PotionEffect potionEffect : potionEffects) {
+            killer.addPotionEffect(new PotionEffect(potionEffect.getType(), potionEffect.getDuration() * 20, potionEffect.getAmplifier(), potionEffect.isAmbient(), potionEffect.hasParticles(), false), true);
+        }
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/FireworkKillstreakAction.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/FireworkKillstreakAction.java
@@ -1,0 +1,18 @@
+package network.warzone.tgm.modules.killstreak;
+
+import lombok.AllArgsConstructor;
+import network.warzone.tgm.util.FireworkUtil;
+import org.bukkit.FireworkEffect;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+@AllArgsConstructor
+class FireworkKillstreakAction implements KillstreakAction {
+    private Location locationOffset;
+    private FireworkEffect fireworkEffect;
+    private int power;
+    @Override
+    public void apply(Player killer) {
+        FireworkUtil.spawnFirework(killer.getLocation().clone().add(locationOffset), fireworkEffect, power);
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/ItemKillstreakAction.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/ItemKillstreakAction.java
@@ -1,0 +1,17 @@
+package network.warzone.tgm.modules.killstreak;
+
+import lombok.AllArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Set;
+
+@AllArgsConstructor
+class ItemKillstreakAction implements KillstreakAction {
+    private Set<ItemStack> items;
+    @Override
+    public void apply(Player killer) {
+        for(ItemStack item : items) killer.getInventory().addItem(item);
+        killer.updateInventory();
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/Killstreak.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/Killstreak.java
@@ -14,6 +14,7 @@ public class Killstreak {
 
     private int count = 0;
     private String message = "";
+    private List<KillstreakAction> actions = new ArrayList<>();
     private List<String> commands = new ArrayList<>();
     private boolean repeat = false;
 
@@ -25,6 +26,11 @@ public class Killstreak {
 
     public Killstreak setMessage(String message) {
         this.message = message;
+        return this;
+    }
+
+    public Killstreak setActions(List<KillstreakAction> actions) {
+        this.actions = actions;
         return this;
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/KillstreakAction.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/KillstreakAction.java
@@ -1,0 +1,7 @@
+package network.warzone.tgm.modules.killstreak;
+
+import org.bukkit.entity.Player;
+
+public interface KillstreakAction {
+    void apply(Player killer);
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/KillstreakModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/KillstreakModule.java
@@ -6,14 +6,19 @@ import lombok.Getter;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
 import network.warzone.tgm.modules.DeathModule;
+import network.warzone.tgm.modules.kit.parser.EffectKitNodeParser;
 import network.warzone.tgm.modules.team.TeamChangeEvent;
 import network.warzone.tgm.util.ColorConverter;
-import org.bukkit.Bukkit;
+import network.warzone.tgm.util.Parser;
+import network.warzone.tgm.util.Strings;
+import org.bukkit.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 
 import java.util.*;
 
@@ -36,47 +41,47 @@ public class KillstreakModule extends MatchModule implements Listener {
                 new Killstreak()
                         .setCount(5)
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &2&l%count%&r&7!")
-                        .setCommands(Collections.singletonList(
-                                "execute at %killername% run playsound entity.zombie.death master @a ~ ~ ~ 3"
+                        .setActions(Collections.singletonList(
+                                new SoundKillstreakAction(Sound.ENTITY_ZOMBIE_DEATH, SoundKillstreakAction.SoundTarget.EVERYONE, 3.0F, 1.0F)
                         )),
 
                 new Killstreak()
                         .setCount(10)
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &6&l%count%&r&7!")
-                        .setCommands(Arrays.asList(
-                                "execute at %killername% run playsound entity.wither.ambient master @a ~ ~ ~ 7",
-                                "execute at %killername% run summon firework_rocket ~ ~ ~ {LifeTime:0,FireworksItem:{id:fireworks,Count:1,tag:{Fireworks:{Explosions:[{Type:4,Colors:[I;16711680],FadeColors:[I;9371648]}]}}}}"
+                        .setActions(Arrays.asList(
+                                new SoundKillstreakAction(Sound.ENTITY_WITHER_AMBIENT, SoundKillstreakAction.SoundTarget.EVERYONE, 7.0F, 1.0F),
+                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.CREEPER).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
                         )),
 
                 new Killstreak()
                         .setCount(25)
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &c&l%count%&r&7!")
-                        .setCommands(Arrays.asList(
-                                "execute at %killername% run playsound entity.ender_dragon.growl master @a ~ ~ ~ 1000",
-                                "execute at %killername% run summon firework_rocket ~ ~ ~ {LifeTime:0,FireworksItem:{id:fireworks,Count:1,tag:{Fireworks:{Explosions:[{Type:0,Colors:[I;16711680],FadeColors:[I;9371648]}]}}}}"
+                        .setActions(Arrays.asList(
+                                new SoundKillstreakAction(Sound.ENTITY_ENDER_DRAGON_GROWL, SoundKillstreakAction.SoundTarget.EVERYONE, 1000.0F, 1.0F),
+                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.BALL).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
                         )),
 
                 new Killstreak()
                         .setCount(50)
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &3&l%count%&r&7!")
-                        .setCommands(Arrays.asList(
-                                "execute at %killername% run playsound entity.wither.spawn master @a ~ ~ ~ 1000 1.4", // 1.4 so it doesn't sound the same as the game end sound
-                                "execute at %killername% run summon firework_rocket ~ ~ ~ {LifeTime:0,FireworksItem:{id:fireworks,Count:1,tag:{Fireworks:{Explosions:[{Type:1,Colors:[I;16711680],FadeColors:[I;9371648]}]}}}}"
+                        .setActions(Arrays.asList(
+                                new SoundKillstreakAction(Sound.ENTITY_WITHER_SPAWN, SoundKillstreakAction.SoundTarget.EVERYONE, 1000.0F, 1.4F),
+                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.BALL_LARGE).withColor(Color.RED).withFade(Color.fromRGB(9371648)).build(), 0)
                         )),
 
                 new Killstreak()
                         .setCount(100)
                         .setMessage("%killercolor%%killername% &7is on a kill streak of &5&l%count%&r&7!")
-                        .setCommands(Arrays.asList(
-                                "execute at %killername% run playsound ui.toast.challenge_complete master @p ~ ~100 ~ 1000",
-                                "execute at %killername% run summon firework_rocket ~ ~ ~ {LifeTime:0,FireworksItem:{id:fireworks,Count:1,tag:{Fireworks:{Explosions:[{Type:2,Colors:[I;16766776],FadeColors:[I;16774912]}]}}}}"//,
-                                //"ban %killername% &c&lDETECTED FOR KILL FARMING&r" // :facepalm:
+                        .setActions(Arrays.asList(
+                                new SoundKillstreakAction(Sound.UI_TOAST_CHALLENGE_COMPLETE, SoundKillstreakAction.SoundTarget.PLAYER, 1000.0F, 1.0F),
+                                new FireworkKillstreakAction(new Location(match.getWorld(), 0.0, 0.0, 0.0), FireworkEffect.builder().with(FireworkEffect.Type.STAR).withColor(Color.fromRGB(16766776)).withFade(Color.fromRGB(16774912)).build(), 0)
                         ))
         ));
 
         if (match.getMapContainer().getMapInfo().getJsonObject().has("killstreaks")) { // If json contains killstreaks, read it
             for (JsonElement streakElement : match.getMapContainer().getMapInfo().getJsonObject().getAsJsonArray("killstreaks")) {
                 Killstreak killstreak = new Killstreak();
+                List<KillstreakAction> killstreakActions = new ArrayList<>();
 
                 JsonObject streakJson = streakElement.getAsJsonObject();
 
@@ -94,10 +99,61 @@ public class KillstreakModule extends MatchModule implements Listener {
                     }});
                 }
 
+                if(streakJson.has("actions")) {
+                    JsonObject actionObj = streakJson.get("actions").getAsJsonObject();
+                    if(actionObj.has("fireworks")) {
+                        for(JsonElement jsonElem : actionObj.getAsJsonArray("fireworks")) {
+                            JsonObject fireworkObj = jsonElem.getAsJsonObject();
+                            String fireworkType = fireworkObj.has("type") ? Strings.getTechnicalName(fireworkObj.get("type").getAsString()) : "BALL";
+                            boolean shouldTrail = fireworkObj.has("trail") ? fireworkObj.get("trail").getAsBoolean() : false;
+                            boolean shouldFlicker = fireworkObj.has("flicker") ? fireworkObj.get("flicker").getAsBoolean() : false;
+                            Set<Color> fireworkColors = new HashSet<>();
+                            if(fireworkObj.has("colors")) {
+                                for(JsonElement elem : fireworkObj.getAsJsonArray("colors")) {
+                                    fireworkColors.add(Color.fromRGB(elem.getAsInt()));
+                                }
+                            }
+                            Set<Color> fadeColors = new HashSet<>();
+                            if(fireworkObj.has("fade_colors")) {
+                                for(JsonElement elem : fireworkObj.getAsJsonArray("fade_colors")) {
+                                    fadeColors.add(Color.fromRGB(elem.getAsInt()));
+                                }
+                            }
+                            int fireworkLifetime = fireworkObj.has("lifetime") ? fireworkObj.get("lifetime").getAsInt() : 0;
+                            Location locationOffset = fireworkObj.has("location_offset") ? Parser.convertLocation(match.getWorld(), fireworkObj.get("location_offset")) : new Location(match.getWorld(), 0.0, 0.0, 0.0);
+                            killstreakActions.add(new FireworkKillstreakAction(locationOffset, FireworkEffect.builder().with(FireworkEffect.Type.valueOf(fireworkType)).trail(shouldTrail).flicker(shouldFlicker).withColor(fireworkColors).withFade(fadeColors).build(), fireworkLifetime));
+                        }
+                    }
+                    if(actionObj.has("items")) {
+                        Set<ItemStack> items = new HashSet<>();
+                        for(JsonElement jsonElem : actionObj.getAsJsonArray("items")) {
+                            JsonObject itemJson = jsonElem.getAsJsonObject();
+                            items.add(Parser.parseItemStack(itemJson));
+                        }
+                        killstreakActions.add(new ItemKillstreakAction(items));
+                    }
+                    if(actionObj.has("sounds")) {
+                        for(JsonElement jsonElem : actionObj.getAsJsonArray("sounds")) {
+                            JsonObject soundObj = jsonElem.getAsJsonObject();
+                            Sound theSound = Sound.valueOf(soundObj.get("sound").getAsString().toUpperCase().replace(".", "_"));
+                            float volume = soundObj.has("volume") ? soundObj.get("volume").getAsFloat() : 1.0F;
+                            float pitch = soundObj.has("pitch") ? soundObj.get("pitch").getAsFloat() : 1.0F;
+                            SoundKillstreakAction.SoundTarget soundTarget = soundObj.has("target") ? SoundKillstreakAction.SoundTarget.valueOf(soundObj.get("target").getAsString().toUpperCase().replace(" ", "_")) : SoundKillstreakAction.SoundTarget.EVERYONE;
+                            killstreakActions.add(new SoundKillstreakAction(theSound, soundTarget, volume, pitch));
+                        }
+                    }
+                    if(actionObj.has("effects")) {
+                        Set<PotionEffect> potionEffects = new HashSet<>();
+                        for(JsonElement jsonElem : actionObj.getAsJsonArray("effects")) potionEffects.add(EffectKitNodeParser.parsePotionEffect(jsonElem.getAsJsonObject()));
+                        killstreakActions.add(new EffectKillstreakAction(potionEffects));
+                    }
+                }
+
                 if (streakJson.has("repeat")) {
                     killstreak.setRepeat(streakJson.get("repeat").getAsBoolean());
                 }
 
+                killstreak.setActions(killstreakActions);
                 killstreaks.add(killstreak);
             }
         }
@@ -145,6 +201,8 @@ public class KillstreakModule extends MatchModule implements Listener {
                             .replace("%killedname%", module.getPlayerName())
                             .replace("%count%", String.valueOf(killstreak.getCount()))
                     );
+
+                killstreak.getActions().forEach(a -> a.apply(module.getKiller()));
 
                 killstreak.getCommands().forEach(s -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), ColorConverter.filterString(s)
                         .replace("%killername%", module.getKillerName())

--- a/TGM/src/main/java/network/warzone/tgm/modules/killstreak/SoundKillstreakAction.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/killstreak/SoundKillstreakAction.java
@@ -1,0 +1,36 @@
+package network.warzone.tgm.modules.killstreak;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+
+
+class SoundKillstreakAction implements KillstreakAction {
+    private Sound sound;
+    private SoundTarget soundTarget;
+    private float volume;
+    private float pitch;
+
+    public SoundKillstreakAction(Sound sound, SoundTarget soundTarget, float volume, float pitch) {
+        this.sound = sound;
+        this.soundTarget = soundTarget;
+        this.volume = volume;
+        this.pitch = pitch;
+    }
+
+    @Override
+    public void apply(Player killer) {
+        if(soundTarget == SoundTarget.EVERYONE) {
+            for(Player p : Bukkit.getOnlinePlayers()) {
+                p.playSound(p.getLocation().clone().add(0.0, 100.0, 0.0), sound, volume, pitch);
+            }
+        } else {
+            if(killer == null) return;
+            killer.playSound(killer.getLocation().clone().add(0.0, 100.0, 0.0), sound, volume, pitch);
+        }
+    }
+
+    enum SoundTarget {
+        EVERYONE, PLAYER
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/kit/parser/EffectKitNodeParser.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/kit/parser/EffectKitNodeParser.java
@@ -17,8 +17,9 @@ public class EffectKitNodeParser implements KitNodeParser {
         return Collections.singletonList(new EffectKitNode(parsePotionEffect(jsonObject)));
     }
 
-    private PotionEffect parsePotionEffect(JsonObject jsonObject) {
+    public static PotionEffect parsePotionEffect(JsonObject jsonObject) {
         PotionEffectType type = PotionEffectType.getByName(Strings.getTechnicalName(jsonObject.get("type").getAsString()));
+
 
         int duration = 30;
         int amplifier = 0;

--- a/TGM/src/main/java/network/warzone/tgm/util/FireworkUtil.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/FireworkUtil.java
@@ -29,4 +29,5 @@ public class FireworkUtil {
         return firework;
     }
 
+
 }

--- a/TGM/src/main/java/network/warzone/tgm/util/Parser.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/Parser.java
@@ -2,12 +2,24 @@ package network.warzone.tgm.util;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import net.minecraft.server.v1_14_R1.IChatBaseComponent;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.util.itemstack.ItemFactory;
+import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.*;
+import org.bukkit.potion.PotionData;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionType;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +61,152 @@ public class Parser {
 
             return new Location(world, x, y, z, yaw, pitch);
         }
+    }
+
+    public static ItemStack parseItemStack(JsonObject jsonObject) {
+        Material material = Material.valueOf(Strings.getTechnicalName(jsonObject.get("material").getAsString()));
+        ItemStack itemStack = ItemFactory.createItem(material);
+        ItemMeta itemMeta = itemStack.getItemMeta();
+
+        if (jsonObject.has("display_name")) {
+            itemMeta.setDisplayName(ColorConverter.filterString(jsonObject.get("display_name").getAsString()));
+        }
+
+        if (jsonObject.has("lore")) {
+            List<String> lore = new ArrayList<>();
+            for (JsonElement element : jsonObject.getAsJsonArray("lore")) {
+                lore.add(ColorConverter.filterString(element.getAsString()));
+            }
+            itemMeta.setLore(lore);
+        }
+
+        if (jsonObject.has("amount")) {
+            itemStack.setAmount(jsonObject.get("amount").getAsInt());
+        }
+
+        if (jsonObject.has("unbreakable")) {
+            itemMeta.setUnbreakable(jsonObject.get("unbreakable").getAsBoolean());
+        }
+
+        if (jsonObject.has("flags")) {
+            for (JsonElement element : jsonObject.getAsJsonArray("flags")) {
+                itemMeta.addItemFlags(ItemFlag.valueOf(Strings.getTechnicalName(element.getAsString())));
+            }
+        }
+
+        // https://hub.spigotmc.org/javadocs/spigot/org/bukkit/enchantments/Enchantment.html
+        if (jsonObject.has("enchantments")) {
+            for (JsonElement element : jsonObject.getAsJsonArray("enchantments")) {
+                String[] split = element.getAsString().split(":");
+                int level = Integer.valueOf(split[1]);
+                Enchantment enchantment = Enchantment.getByName(Strings.getTechnicalName(split[0]));
+                if (enchantment != null) {
+                    itemMeta.addEnchant(enchantment, level, true);
+                }
+            }
+        }
+
+        if (jsonObject.has("durability")) {
+            itemStack.setDurability(jsonObject.get("durability").getAsShort());
+        }
+
+        if (material.equals(Material.PLAYER_HEAD) && jsonObject.has("skullOwner")) {
+            SkullMeta skullMeta = (SkullMeta) itemMeta;
+            skullMeta.setOwner(jsonObject.get("skullOwner").getAsString());
+            itemStack.setItemMeta(skullMeta);
+        }
+
+
+        if (material.name().contains("POTION") && jsonObject.has("potion")) {
+            PotionMeta potionMeta = (PotionMeta) itemMeta;
+
+            /*
+            https://hub.spigotmc.org/javadocs/spigot/org/bukkit/potion/PotionEffectType.html
+            "potion": {"effects": ["<effect>:<time> [amplifier]"]}
+            */
+            if (jsonObject.getAsJsonObject("potion").has("effects")) {
+                for (JsonElement element : jsonObject.getAsJsonObject("potion").getAsJsonArray("effects")) {
+                    String[] split = element.getAsString().replace(": ", ":").split(":");
+                    PotionEffectType effectType = PotionEffectType.getByName(Strings.getTechnicalName(split[0]));
+                    int duration;
+                    int level = 0;
+                    if (split[1].contains(" ")) {
+                        duration = Integer.valueOf(split[1].split(" ")[0]); // ticks
+                        level = Integer.valueOf(split[1].split(" ")[1]);
+                    } else {
+                        duration = Integer.valueOf(split[1]);
+                    }
+                    if (effectType != null) potionMeta.addCustomEffect(new PotionEffect(effectType, duration, level), true);
+                }
+            }
+
+            /*
+            Used to get potions that can be obtained from the Creative Inventory
+            https://hub.spigotmc.org/javadocs/spigot/org/bukkit/potion/PotionType.html
+            "potion": {
+                 "type": "<type>",
+                 "extend": <boolean>,    Only used if "type" exists
+                 "upgrade": <boolean>    Only used if "type" exists
+            }
+            */
+            if (jsonObject.getAsJsonObject("potion").has("type")) {
+                PotionType type = PotionType.valueOf(Strings.getTechnicalName(jsonObject.getAsJsonObject("potion").get("type").getAsString()));
+                boolean extended = false;
+                boolean upgraded = false;
+                if (type == null) type = PotionType.UNCRAFTABLE;
+                if (jsonObject.getAsJsonObject("potion").has("extend")) extended = jsonObject.getAsJsonObject("potion").get("type").getAsBoolean();
+                if (jsonObject.getAsJsonObject("potion").has("upgrade")) upgraded = jsonObject.getAsJsonObject("potion").get("upgrade").getAsBoolean();
+                potionMeta.setBasePotionData(new PotionData(type, extended, upgraded));
+            }
+
+            itemStack.setItemMeta(potionMeta);
+        }
+
+        //TODO Clean this up with new kit module
+        if (material.equals(Material.WRITTEN_BOOK)) {
+            BookMeta bookMeta = (BookMeta) itemMeta;
+
+            bookMeta.setTitle(jsonObject.has("title") ? ColorConverter.filterString(jsonObject.get("title").getAsString()) : "Empty Book");
+            bookMeta.setAuthor(jsonObject.has("author") ? ColorConverter.filterString(jsonObject.get("author").getAsString()) : "Mojang");
+            bookMeta.setGeneration(jsonObject.has("generation") ?
+                    BookMeta.Generation.valueOf(Strings.getTechnicalName(jsonObject.get("generation").getAsString())) : BookMeta.Generation.ORIGINAL);
+
+            if (jsonObject.has("pages")) { // Json pages
+                try {
+                    Field pagesField = Class.forName("org.bukkit.craftbukkit.v1_14_R1.inventory.CraftMetaBook").getDeclaredField("pages");
+                    pagesField.setAccessible(true);
+
+                    List<IChatBaseComponent> pages = (List<IChatBaseComponent>) pagesField.get(bookMeta);
+                    jsonObject.getAsJsonArray("pages").forEach(jsonElement -> pages.add(IChatBaseComponent.ChatSerializer.a(ColorConverter.filterString(jsonElement.getAsString()))));
+
+                    pagesField.setAccessible(false);
+                } catch (NoSuchFieldException | ClassNotFoundException | IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                bookMeta.addPage("null");
+            }
+
+            itemStack.setItemMeta(bookMeta);
+        }
+
+        if (jsonObject.has("color")) {
+            String[] rgb = jsonObject.get("color").getAsString().replace(" ", "").split(",");
+            Color color = Color.fromRGB(Integer.valueOf(rgb[0]), Integer.valueOf(rgb[1]), Integer.valueOf(rgb[2]));
+            if (material.name().contains("LEATHER_")) { // Leather armor
+                LeatherArmorMeta leatherArmorMeta = (LeatherArmorMeta) itemMeta;
+                leatherArmorMeta.setColor(color);
+                itemStack.setItemMeta(leatherArmorMeta);
+            } else if (material.name().contains("POTION")) {
+                PotionMeta potionMeta = (PotionMeta) itemMeta;
+                potionMeta.setColor(color);
+                itemStack.setItemMeta(potionMeta);
+            }
+        }
+
+        itemStack.setItemMeta(itemMeta);
+
+        return itemStack;
     }
 
     public static List<MatchTeam> getTeamsFromElement(TeamManagerModule teamManagerModule, JsonElement element) {


### PR DESCRIPTION
This includes pre-defined actions for the KillstreakModule instead of using commands for all reward actions. Includes Effects, Items, Fireworks, and Sounds. Resolves #485 

Example JSON for new actions:

![example json](https://i.vgy.me/vNKzO1.png)

Note: Commands are not removed, Actions were simply added. So this means old map.json files will still work.