### PR TITLE
UUID support for authors

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -1,17 +1,15 @@
 package network.warzone.tgm.command;
 
-import com.google.common.base.Joiner;
 import com.sk89q.minecraft.util.commands.*;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.api.ChatColor;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.gametype.GameType;
 import network.warzone.tgm.map.MapContainer;
 import network.warzone.tgm.map.MapInfo;
-import network.warzone.tgm.map.MapLibrary;
 import network.warzone.tgm.match.MatchManager;
 import network.warzone.tgm.match.MatchStatus;
 import network.warzone.tgm.modules.ChatModule;
@@ -27,9 +25,7 @@ import network.warzone.tgm.modules.time.TimeModule;
 import network.warzone.tgm.user.PlayerContext;
 import network.warzone.tgm.util.ColorConverter;
 import network.warzone.tgm.util.Strings;
-import network.warzone.warzoneapi.models.Author;
 import network.warzone.warzoneapi.models.GetPlayerByNameResponse;
-import network.warzone.warzoneapi.models.Map;
 import network.warzone.warzoneapi.models.UserProfile;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -11,6 +11,7 @@ import network.warzone.tgm.TGM;
 import network.warzone.tgm.gametype.GameType;
 import network.warzone.tgm.map.MapContainer;
 import network.warzone.tgm.map.MapInfo;
+import network.warzone.tgm.map.MapLibrary;
 import network.warzone.tgm.match.MatchManager;
 import network.warzone.tgm.match.MatchStatus;
 import network.warzone.tgm.modules.ChatModule;
@@ -26,7 +27,9 @@ import network.warzone.tgm.modules.time.TimeModule;
 import network.warzone.tgm.user.PlayerContext;
 import network.warzone.tgm.util.ColorConverter;
 import network.warzone.tgm.util.Strings;
+import network.warzone.warzoneapi.models.Author;
 import network.warzone.warzoneapi.models.GetPlayerByNameResponse;
+import network.warzone.warzoneapi.models.Map;
 import network.warzone.warzoneapi.models.UserProfile;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
@@ -94,22 +97,9 @@ public class CycleCommands {
         sender.sendMessage(ChatColor.YELLOW + "Maps (" + index + "/" + pages + "): ");
         try {
             for (int i = 0; i < pageSize; i++) {
-                int position = pageSize * (index - 1) + i;
+                int position = 9 * (index - 1) + i;
                 MapContainer map = mapLibrary.get(position);
-                String mapName = ChatColor.GOLD + map.getMapInfo().getName();
-
-                if (map.getMapInfo().equals(TGM.get().getMatchManager().getMatch().getMapContainer().getMapInfo())) {
-                    mapName = ChatColor.GREEN + "" + (position + 1) + ". " + mapName;
-                } else {
-                    mapName = ChatColor.WHITE + "" + (position + 1) + ". " + mapName;
-                }
-                TextComponent message = new TextComponent(mapName);
-                message.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/sn " + mapLibrary.get(position).getMapInfo().getName()));
-                message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(ChatColor.GOLD + mapLibrary.get(position).getMapInfo().getName()).append("\n\n")
-                        .append(ChatColor.GRAY + "Authors: ").append(Joiner.on(", ").join(mapLibrary.get(position).getMapInfo().getAuthors())).append("\n")
-                        .append(ChatColor.GRAY + "Game Type: ").append(ChatColor.YELLOW + map.getMapInfo().getGametype().toString()).append("\n")
-                        .append(ChatColor.GRAY + "Version: ").append(ChatColor.YELLOW + mapLibrary.get(position).getMapInfo().getVersion()).create()));
-
+                TextComponent message = mapToTextComponent(position, map.getMapInfo());
                 sender.spigot().sendMessage(message);
             }
         } catch (IndexOutOfBoundsException ignored) {}
@@ -154,20 +144,7 @@ public class CycleCommands {
             for (int i = 0; i < pageSize; i++) {
                 int position = pageSize * (index - 1) + i;
                 MapContainer map = mapLibrary.get(foundMaps.get(position));
-                String mapName = ChatColor.GOLD + map.getMapInfo().getName();
-
-                if (map.getMapInfo().equals(TGM.get().getMatchManager().getMatch().getMapContainer().getMapInfo())) {
-                    mapName = ChatColor.GREEN + "" + (position + 1) + ". " + mapName;
-                } else {
-                    mapName = ChatColor.WHITE + "" + (position + 1) + ". " + mapName;
-                }
-                TextComponent message = new TextComponent(mapName);
-                message.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/sn " + map.getMapInfo().getName()));
-                message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(ChatColor.GOLD + map.getMapInfo().getName()).append("\n\n")
-                        .append(ChatColor.GRAY + "Authors: ").append(Joiner.on(", ").join(map.getMapInfo().getAuthors())).append("\n")
-                        .append(ChatColor.GRAY + "Game Type: ").append(ChatColor.YELLOW + map.getMapInfo().getGametype().toString()).append("\n")
-                        .append(ChatColor.GRAY + "Version: ").append(ChatColor.YELLOW + map.getMapInfo().getVersion()).create()));
-
+                TextComponent message = mapToTextComponent(position, map.getMapInfo());
                 sender.spigot().sendMessage(message);
             }
         } catch (IndexOutOfBoundsException ignored) {}
@@ -197,20 +174,7 @@ public class CycleCommands {
             for (int i = 0; i < pageSize; i++) {
                 int position = 9 * (index - 1) + i;
                 MapContainer map = rotation.get(position);
-                String mapName = ChatColor.GOLD + map.getMapInfo().getName();
-
-                if (map.getMapInfo().equals(TGM.get().getMatchManager().getMatch().getMapContainer().getMapInfo())) {
-                    mapName = ChatColor.GREEN + "" + (position + 1) + ". " + mapName;
-                } else {
-                    mapName = ChatColor.WHITE + "" + (position + 1) + ". " + mapName;
-                }
-                TextComponent message = new TextComponent(mapName);
-                message.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/sn " + rotation.get(position).getMapInfo().getName()));
-                message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(ChatColor.GOLD + rotation.get(position).getMapInfo().getName()).append("\n\n")
-                        .append(ChatColor.GRAY + "Authors: ").append(Joiner.on(", ").join(rotation.get(position).getMapInfo().getAuthors())).append("\n")
-                        .append(ChatColor.GRAY + "Game Type: ").append(ChatColor.YELLOW + map.getMapInfo().getGametype().toString()).append("\n")
-                        .append(ChatColor.GRAY + "Version: ").append(ChatColor.YELLOW + rotation.get(position).getMapInfo().getVersion()).create()));
-
+                TextComponent message = mapToTextComponent(position, map.getMapInfo());
                 sender.spigot().sendMessage(message);
             }
         } catch (IndexOutOfBoundsException ignored) { }
@@ -563,13 +527,13 @@ public class CycleCommands {
     @Command(aliases = {"next"}, desc = "View the next map in the rotation")
     public static void next(CommandContext cmd, CommandSender sender) {
         MapInfo info = TGM.get().getMatchManager().getNextMap().getMapInfo();
-        sender.sendMessage(ChatColor.GRAY + "Next Map: " + ChatColor.YELLOW + info.getName() + ChatColor.GRAY + " by " + ChatColor.YELLOW + String.join(", ", info.getAuthors()));
+        sender.sendMessage(ChatColor.GRAY + "Next Map: " + ChatColor.YELLOW + info.getName() + ChatColor.GRAY + " by " + ChatColor.YELLOW + String.join(", ", info.getAuthors().stream().map(Strings::getAuthorUsername).collect(Collectors.joining(", "))));
     }
     
     @Command(aliases = {"map"}, desc = "View the map info for the current map")
     public static void map(CommandContext cmd, CommandSender sender) {
         MapInfo info = TGM.get().getMatchManager().getMatch().getMapContainer().getMapInfo();
-        sender.sendMessage(ChatColor.GRAY + "Currently playing " + ChatColor.YELLOW + info.getGametype() + ChatColor.GRAY + " on map " + ChatColor.YELLOW + info.getName() + ChatColor.GRAY + " by " + ChatColor.YELLOW + info.getAuthors().stream().collect(Collectors.joining(", ")));
+        sender.sendMessage(ChatColor.GRAY + "Currently playing " + ChatColor.YELLOW + info.getGametype() + ChatColor.GRAY + " on map " + ChatColor.YELLOW + info.getName() + ChatColor.GRAY + " by " + ChatColor.YELLOW + info.getAuthors().stream().map(Strings::getAuthorUsername).collect(Collectors.joining(", ")));
     }
 
     @Command(aliases = {"time"}, desc = "Time options")
@@ -760,5 +724,22 @@ public class CycleCommands {
         }));
         main.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/stats " + profile.getName()));
         return main;
+    }
+
+    private static TextComponent mapToTextComponent(int position, MapInfo mapInfo) {
+        String mapName = ChatColor.GOLD + mapInfo.getName();
+
+        if (mapInfo.equals(TGM.get().getMatchManager().getMatch().getMapContainer().getMapInfo())) {
+            mapName = ChatColor.GREEN + "" + (position + 1) + ". " + mapName;
+        } else {
+            mapName = ChatColor.WHITE + "" + (position + 1) + ". " + mapName;
+        }
+        TextComponent message = new TextComponent(mapName);
+        message.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/sn " + mapInfo.getName()));
+        message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(ChatColor.GOLD + mapInfo.getName()).append("\n\n")
+                .append(ChatColor.GRAY + "Authors: ").append(ChatColor.YELLOW + mapInfo.getAuthors().stream().map(Strings::getAuthorUsername).collect(Collectors.joining(", "))).append("\n")
+                .append(ChatColor.GRAY + "Game Type: ").append(ChatColor.YELLOW + mapInfo.getGametype().toString()).append("\n")
+                .append(ChatColor.GRAY + "Version: ").append(ChatColor.YELLOW + mapInfo.getVersion()).create()));
+        return message;
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/map/MapInfo.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapInfo.java
@@ -1,10 +1,9 @@
 package network.warzone.tgm.map;
 
 import com.google.gson.JsonObject;
-import lombok.EqualsAndHashCode;
-import network.warzone.tgm.gametype.GameType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import network.warzone.tgm.gametype.GameType;
 import network.warzone.warzoneapi.models.Author;
 
 import java.util.List;

--- a/TGM/src/main/java/network/warzone/tgm/map/MapInfo.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapInfo.java
@@ -1,9 +1,11 @@
 package network.warzone.tgm.map;
 
 import com.google.gson.JsonObject;
+import lombok.EqualsAndHashCode;
 import network.warzone.tgm.gametype.GameType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import network.warzone.warzoneapi.models.Author;
 
 import java.util.List;
 
@@ -14,7 +16,7 @@ import java.util.List;
 public class MapInfo {
     private String name;
     private String version;
-    private List<String> authors;
+    private List<Author> authors;
     private GameType gametype;
     private List<ParsedTeam> teams;
     private JsonObject jsonObject;

--- a/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
@@ -1,9 +1,7 @@
 package network.warzone.tgm.map;
 
 import com.google.gson.*;
-import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.gametype.GameType;
 import network.warzone.warzoneapi.models.Author;

--- a/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
@@ -1,12 +1,19 @@
 package network.warzone.tgm.map;
 
 import com.google.gson.*;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import network.warzone.tgm.TGM;
 import network.warzone.tgm.gametype.GameType;
+import network.warzone.warzoneapi.models.Author;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Created by luke on 4/27/17.
@@ -17,9 +24,23 @@ public class MapInfoDeserializer implements JsonDeserializer<MapInfo> {
         JsonObject json = jsonElement.getAsJsonObject();
         String name = json.get("name").getAsString();
         String version = json.get("version").getAsString();
-        List<String> authors = new ArrayList<>();
+        List<Author> authors = new ArrayList<>();
         for (JsonElement authorJson : json.getAsJsonArray("authors")) {
-            authors.add(authorJson.getAsString());
+            if (authorJson.isJsonPrimitive()) {
+                authors.add(new Author(authorJson.getAsString()));
+            } else {
+                Author author = TGM.get().getGson().fromJson(authorJson, Author.class);
+                Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> {
+                    if (author != null && author.getUuid() != null) {
+                        try {
+                            author.setDisplayUsername(getCurrentName(author.getUuid()));
+                        } catch (Exception e) {
+                            TGM.get().getLogger().warning("Could not retrieve current name for " + author.getUuid().toString() + " on map " + name);
+                        }
+                    }
+                });
+                authors.add(author);
+            }
         }
         GameType gameType = GameType.valueOf(json.get("gametype").getAsString());
         List<ParsedTeam> parsedTeams = new ArrayList<>();
@@ -35,4 +56,16 @@ public class MapInfoDeserializer implements JsonDeserializer<MapInfo> {
 
         return new MapInfo(name, version, authors, gameType, parsedTeams, json);
     }
+
+    private static String getCurrentName(UUID uuid) throws Exception {
+        MojangProfile[] body = Unirest.get("https://api.mojang.com/user/profiles/" + uuid.toString().replace("-", "") + "/names")
+                .asObject(MojangProfile[].class)
+                .getBody();
+        return body[body.length - 1].name;
+    }
+
+    private static class MojangProfile {
+        private String name;
+    }
+
 }

--- a/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
+++ b/TGM/src/main/java/network/warzone/tgm/map/MapInfoDeserializer.java
@@ -28,15 +28,16 @@ public class MapInfoDeserializer implements JsonDeserializer<MapInfo> {
                 authors.add(new Author(authorJson.getAsString()));
             } else {
                 Author author = TGM.get().getGson().fromJson(authorJson, Author.class);
-                Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> {
-                    if (author != null && author.getUuid() != null) {
-                        try {
-                            author.setDisplayUsername(getCurrentName(author.getUuid()));
-                        } catch (Exception e) {
-                            TGM.get().getLogger().warning("Could not retrieve current name for " + author.getUuid().toString() + " on map " + name);
+                if (TGM.get().getConfig().getBoolean("map.get-names"))
+                    Bukkit.getScheduler().runTaskAsynchronously(TGM.get(), () -> {
+                        if (author != null && author.getUuid() != null) {
+                            try {
+                                author.setDisplayUsername(getCurrentName(author.getUuid()));
+                            } catch (Exception e) {
+                                TGM.get().getLogger().warning("Could not retrieve current name for " + author.getUuid().toString() + " on map " + name);
+                            }
                         }
-                    }
-                });
+                    });
                 authors.add(author);
             }
         }

--- a/TGM/src/main/java/network/warzone/tgm/util/Strings.java
+++ b/TGM/src/main/java/network/warzone/tgm/util/Strings.java
@@ -1,5 +1,7 @@
 package network.warzone.tgm.util;
 
+import network.warzone.warzoneapi.models.Author;
+
 public class Strings {
     public static String formatTime(double time) {
         boolean negative = false;
@@ -47,6 +49,10 @@ public class Strings {
         } else {
             return "moments";
         }
+    }
+
+    public static String getAuthorUsername(Author author) {
+        return author.getDisplayUsername() != null ? author.getDisplayUsername() : author.getUsername() != null ? author.getUsername() : "Unknown";
     }
 
 }

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -11,6 +11,7 @@ chat:
   messages:
     muted: "&cChat is currently disabled. If you believe this is an error, please contact a staff member on our Discord."
 map:
+  get-names: false
   sources:
   - Maps
 server:

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/Author.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/Author.java
@@ -1,0 +1,26 @@
+package network.warzone.warzoneapi.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+/**
+ * Created by Jorge on 09/08/2019
+ */
+@Getter @AllArgsConstructor
+public class Author {
+
+    public Author(UUID uuid) {
+        this(uuid, null, null);
+    }
+
+    public Author(String username) {
+        this(null, username, null);
+    }
+
+    private final UUID uuid;
+    private final String username; // Fallback
+    @Setter private String displayUsername;
+}

--- a/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/Map.java
+++ b/WarzoneAPI/src/main/java/network/warzone/warzoneapi/models/Map.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class Map {
     @Getter private String name;
     @Getter private String version;
-    @Getter private List<String> authors;
+    @Getter private List<Author> authors;
     @Getter private String gametype;
     @Getter private List<Team> teams;
 }


### PR DESCRIPTION
Adds support for UUID based authors, without removing support for the string based system. Authors can be defined either as single strings or JSON objects.

Example structure:

```JSON
    "authors": [
        "Notch",
        {"uuid": "61699b2e-d327-4a01-9f1e-0ea8c3f06bc6", "username": "Dinnerbone"}
    ]
```

Not setting the username field will default to `Unknown` if the name retrieval fails or the `map.get-names` configuration option is set to false.

Resolves #456.