### PR TITLE
Match Statistics

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/match/Match.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/Match.java
@@ -40,6 +40,7 @@ public class Match {
      */
     public void load() {
         modules.addAll(matchManifest.allocateCoreModules());
+        modules.addAll(matchManifest.allocateConditionalModules());
         modules.addAll(matchManifest.allocateGameModules());
 
         /*

--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
@@ -1,5 +1,6 @@
 package network.warzone.tgm.match;
 
+import network.warzone.tgm.TGM;
 import network.warzone.tgm.modules.*;
 import network.warzone.tgm.modules.border.WorldBorderModule;
 import network.warzone.tgm.modules.countdown.CycleCountdown;
@@ -15,6 +16,7 @@ import network.warzone.tgm.modules.portal.PortalLoaderModule;
 import network.warzone.tgm.modules.region.RegionManagerModule;
 import network.warzone.tgm.modules.reports.ReportsModule;
 import network.warzone.tgm.modules.scoreboard.ScoreboardManagerModule;
+import network.warzone.tgm.modules.stats.MatchStatsModule;
 import network.warzone.tgm.modules.tasked.TaskedModuleManager;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.modules.time.TimeModule;
@@ -79,6 +81,16 @@ public abstract class MatchManifest {
         modules.add(new WorldBorderModule());
         modules.add(new KnockbackModule());
         modules.add(new MapCommandsModule());
+        return modules;
+    }
+
+    /**
+     * Modules that are added depending on configuration
+     * @return
+     */
+    public List<MatchModule> allocateConditionalModules() {
+        List<MatchModule> modules = new ArrayList<>();
+        if(TGM.get().getConfig().getBoolean("chat.stats-summary")) modules.add(new MatchStatsModule());
         return modules;
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/stats/MatchStatsModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/stats/MatchStatsModule.java
@@ -1,0 +1,70 @@
+package network.warzone.tgm.modules.stats;
+
+import network.warzone.tgm.TGM;
+import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.match.MatchResultEvent;
+import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.team.TeamChangeEvent;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.user.PlayerContext;
+import network.warzone.warzoneapi.models.UserProfile;
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+public class MatchStatsModule extends MatchModule implements Listener {
+    private HashMap<UUID, PlayerStatsCache> playerStatsMap = new HashMap<>();
+
+    @Override
+    public void enable() {
+        List<MatchTeam> teams = TGM.get().getMatchManager().getMatch().getModule(TeamManagerModule.class).getTeams();
+        for(MatchTeam matchTeam : teams) {
+            if (matchTeam.isSpectator()) continue;
+            for(PlayerContext ctx : matchTeam.getMembers()) {
+                UserProfile userProfile = ctx.getUserProfile();
+                playerStatsMap.put(ctx.getPlayer().getUniqueId(), new PlayerStatsCache(userProfile.getKills(), userProfile.getDeaths(), userProfile.getXP()));
+            }
+        }
+    }
+
+    @EventHandler
+    public void onTeamChange(TeamChangeEvent event) {
+        if(!event.getTeam().isSpectator() && !playerStatsMap.containsKey(event.getPlayerContext().getPlayer().getUniqueId())) {
+            UserProfile userProfile = event.getPlayerContext().getUserProfile();
+            playerStatsMap.put(event.getPlayerContext().getPlayer().getUniqueId(), new PlayerStatsCache(userProfile.getKills(), userProfile.getDeaths(), userProfile.getXP()));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onMatchResult(MatchResultEvent event) {
+        List<MatchTeam> teams = event.getMatch().getModule(TeamManagerModule.class).getTeams();
+        for (MatchTeam matchTeam : teams) {
+            if (matchTeam.isSpectator()) continue;
+            for(PlayerContext ctx : matchTeam.getMembers()) {
+                UserProfile userProfile = ctx.getUserProfile();
+                PlayerStatsCache delta = calculateStatsDelta(new PlayerStatsCache(userProfile.getKills(), userProfile.getDeaths(), userProfile.getXP()), playerStatsMap.get(ctx.getPlayer().getUniqueId()));
+                ctx.getPlayer().sendMessage(ChatColor.BLUE + "-------------------------------");
+                ctx.getPlayer().sendMessage("   " + ChatColor.GREEN + delta.getKills() + " Kills");
+                ctx.getPlayer().sendMessage("   " + ChatColor.RED + delta.getDeaths() + " Deaths");
+                ctx.getPlayer().sendMessage("   " + ChatColor.AQUA + delta.getXp() + " XP");
+                ctx.getPlayer().sendMessage(ChatColor.BLUE + "-------------------------------");
+            }
+        }
+    }
+
+    private static PlayerStatsCache calculateStatsDelta(PlayerStatsCache newData, PlayerStatsCache oldData) {
+        if(oldData == null) return new PlayerStatsCache(0, 0, 0);
+        return new PlayerStatsCache(newData.getKills() - oldData.getKills(), newData.getDeaths() - oldData.getDeaths(), newData.getXp() - oldData.getXp());
+    }
+
+
+    @Override
+    public void unload() {
+        playerStatsMap = null;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/stats/PlayerStatsCache.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/stats/PlayerStatsCache.java
@@ -1,0 +1,11 @@
+package network.warzone.tgm.modules.stats;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class PlayerStatsCache {
+    private int kills;
+    private int deaths;
+    private int xp;
+}

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -6,6 +6,7 @@ api:
     enabled: true
 rotation: Maps/rotation.txt
 chat:
+  stats-summary: true
   enabled: true
   stats-hover: true
   messages:


### PR DESCRIPTION
Sends how many kills, deaths, and xp you got at the end of a match. Enabled/Disabled through config option `chat.stats-summary`

Resolves #539 