### PR TITLE
Damage Control

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
@@ -4,6 +4,7 @@ import network.warzone.tgm.modules.*;
 import network.warzone.tgm.modules.border.WorldBorderModule;
 import network.warzone.tgm.modules.countdown.CycleCountdown;
 import network.warzone.tgm.modules.countdown.StartCountdown;
+import network.warzone.tgm.modules.damage.DamageControlModule;
 import network.warzone.tgm.modules.death.DeathMessageModule;
 import network.warzone.tgm.modules.death.DeathModule;
 import network.warzone.tgm.modules.filter.FilterManagerModule;
@@ -79,6 +80,7 @@ public abstract class MatchManifest {
         modules.add(new WorldBorderModule());
         modules.add(new KnockbackModule());
         modules.add(new MapCommandsModule());
+        modules.add(new DamageControlModule());
         return modules;
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/damage/DamageControlModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/damage/DamageControlModule.java
@@ -18,8 +18,8 @@ public class DamageControlModule extends MatchModule implements Listener {
     @Override
     public void load(Match match) {
         JsonObject matchObj = match.getMapContainer().getMapInfo().getJsonObject();
-        if (matchObj.has("damage_control")) {
-            JsonObject damageControlObj = matchObj.getAsJsonObject("damage_control");
+        if (matchObj.has("damageControl")) {
+            JsonObject damageControlObj = matchObj.getAsJsonObject("damageControl");
             if (damageControlObj.has("fire")) fireDamage = damageControlObj.get("fire").getAsBoolean();
             if (damageControlObj.has("fall")) fallDamage = damageControlObj.get("fall").getAsBoolean();
             if (damageControlObj.has("suffocation")) suffocationDamage = damageControlObj.get("suffocation").getAsBoolean();

--- a/TGM/src/main/java/network/warzone/tgm/modules/damage/DamageControlModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/damage/DamageControlModule.java
@@ -1,0 +1,37 @@
+package network.warzone.tgm.modules.damage;
+
+import com.google.gson.JsonObject;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.match.MatchModule;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+import static org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+
+public class DamageControlModule extends MatchModule implements Listener {
+    private boolean fireDamage = true;
+    private boolean fallDamage = true;
+    private boolean suffocationDamage = true;
+
+    @Override
+    public void load(Match match) {
+        JsonObject matchObj = match.getMapContainer().getMapInfo().getJsonObject();
+        if (matchObj.has("damage_control")) {
+            JsonObject damageControlObj = matchObj.getAsJsonObject("damage_control");
+            if (damageControlObj.has("fire")) fireDamage = damageControlObj.get("fire").getAsBoolean();
+            if (damageControlObj.has("fall")) fallDamage = damageControlObj.get("fall").getAsBoolean();
+            if (damageControlObj.has("suffocation")) suffocationDamage = damageControlObj.get("suffocation").getAsBoolean();
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onDamage(EntityDamageEvent event) {
+        boolean shouldCancel = false;
+        if((event.getCause() == DamageCause.FIRE || event.getCause() == DamageCause.FIRE_TICK) && !fireDamage) shouldCancel = true;
+        else if(event.getCause() == DamageCause.SUFFOCATION && !suffocationDamage) shouldCancel = true;
+        else if(event.getCause() == DamageCause.FALL && !fallDamage) shouldCancel = true;
+        event.setCancelled(shouldCancel);
+    }
+}


### PR DESCRIPTION
Choose certain types of damage to not apply in map.json (in this case: fire, suffocation, fall).

```json
"damageControl": {
   "fire": false,
   "suffocation": false,
   "fall": false
}
```
In the example JSON, fire, fall, and suffocation damage would not apply to players.

Resolves #521 