### PR TITLE
Filter rework

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/FilterManagerModule.java
@@ -15,6 +15,7 @@ import network.warzone.tgm.modules.region.RegionManagerModule;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.util.Parser;
+import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 
@@ -60,100 +61,25 @@ public class FilterManagerModule extends MatchModule {
     private List<FilterType> initFilter(Match match, JsonObject jsonObject) {
         List<FilterType> filterTypes = new ArrayList<>();
 
-        String type = jsonObject.get("type").getAsString().toLowerCase();
+        String type = jsonObject.get("type").getAsString()
+                .replace(" ", "")
+                .replace("_", "")
+                .replace("-", "")
+                .toLowerCase();
 
-        if (type.equals("build")) {
-            List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
-            List<Region> regions = new ArrayList<>();
-
-            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
-                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
-                if (region != null) {
-                    regions.add(region);
-                }
-            }
-
-            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
-            String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
-
-            filterTypes.add(new BuildFilterType(matchTeams, regions, filterEvaluator, message));
-        } else if (type.equals("enter")) {
-            List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
-            List<Region> regions = new ArrayList<>();
-
-            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
-                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
-                if (region != null) {
-                    regions.add(region);
-                }
-            }
-
-            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
-            String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
-
-            filterTypes.add(new EnterFilterType(matchTeams, regions, filterEvaluator, message));
-        } else if (type.equals("use-bow")) {
-            List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
-            List<Region> regions = new ArrayList<>();
-
-            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
-                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
-                if (region != null) {
-                    regions.add(region);
-                }
-            }
-
-            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
-            String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
-
-            filterTypes.add(new UseBowFilterType(matchTeams, regions, filterEvaluator, message));
-        } else if (type.equals("use-shear")) {
-            List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
-            List<Region> regions = new ArrayList<>();
-
-            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
-                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
-                if (region != null) {
-                    regions.add(region);
-                }
-            }
-
-            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
-            String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
-
-            filterTypes.add(new UseShearFilterType(matchTeams, regions, filterEvaluator, message));     
-        } else if (type.equals("leave")) {
-            List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
-            List<Region> regions = new ArrayList<>();
-
-            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
-                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
-                if (region != null) {
-                    regions.add(region);
-                }
-            }
-
-            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
-            String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
-
-            filterTypes.add(new LeaveFilterType(matchTeams, regions, filterEvaluator, message));
-        } else if (type.equals("block-explode")) {
-            List<Region> regions = new ArrayList<>();
-            for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
-                Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
-                if (region != null) {
-                    regions.add(region);
-                }
-            }
-
-            FilterEvaluator filterEvaluator = initEvaluator(match, jsonObject);
-            filterTypes.add(new BlockExplodeFilterType(regions, filterEvaluator));
-        }
+        if (type.equals("build"))               filterTypes.add(BuildFilterType.parse(match, jsonObject));
+        else if (type.equals("enter"))          filterTypes.add(EnterFilterType.parse(match, jsonObject));
+        else if (type.equals("usebow"))         filterTypes.add(UseBowFilterType.parse(match, jsonObject));
+        else if (type.equals("useshear"))       filterTypes.add(UseShearFilterType.parse(match, jsonObject));
+        else if (type.equals("leave"))          filterTypes.add(LeaveFilterType.parse(match, jsonObject));
+        else if (type.equals("blockexplode"))   filterTypes.add(BlockExplodeFilterType.parse(match, jsonObject));
+        else if (type.equals("blockplace"))     filterTypes.add(BlockPlaceFilterType.parse(match, jsonObject));
+        else if (type.equals("blockbreak"))     filterTypes.add(BlockBreakFilterType.parse(match, jsonObject));
 
         return filterTypes;
     }
 
-    private FilterEvaluator initEvaluator(Match match, JsonObject parent) {
+    public static FilterEvaluator initEvaluator(Match match, JsonObject parent) {
         switch (parent.get("evaluate").getAsString()) {
             case "allow":
                 return new AllowFilterEvaluator();

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockBreakFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockBreakFilterType.java
@@ -2,6 +2,8 @@ package network.warzone.tgm.modules.filter.type;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import net.md_5.bungee.api.ChatColor;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.modules.filter.FilterManagerModule;
@@ -10,46 +12,62 @@ import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
 import network.warzone.tgm.modules.region.Region;
 import network.warzone.tgm.modules.region.RegionManagerModule;
 import network.warzone.tgm.modules.team.MatchTeam;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.util.Parser;
+import network.warzone.tgm.util.Strings;
+import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.block.BlockBreakEvent;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Created by Jorge on 10/03/2019
+ */
 @AllArgsConstructor @Getter
-public class EnterFilterType implements FilterType, Listener {
+public class BlockBreakFilterType implements FilterType, Listener {
+
     private final List<MatchTeam> teams;
     private final List<Region> regions;
     private final FilterEvaluator evaluator;
     private final String message;
+    private final List<Material> blocks;
 
-    @EventHandler
-    public void onMove(PlayerMoveEvent event) {
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onBlockPlaceEvent(BlockBreakEvent event) {
         for (Region region : regions) {
-            if (region.contains(event.getTo())) {
+            if (region.contains(event.getBlock().getLocation())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
-                        if (filterResult == FilterResult.DENY) {
+                        if (!canBreak(event, filterResult)) {
                             event.setCancelled(true);
                             event.getPlayer().sendMessage(message);
-                        } else if (filterResult == FilterResult.ALLOW) {
-                            event.setCancelled(false);
                         }
+                        break;
                     }
                 }
             }
         }
     }
 
-    public static EnterFilterType parse(Match match, JsonObject jsonObject) {
+    private boolean canBreak(BlockBreakEvent event, FilterResult filterResult) {
+        if (filterResult == FilterResult.ALLOW) {
+            if (blocks == null || blocks.isEmpty()) return true;
+            return blocks.contains(event.getBlock().getType());
+        } else {
+            if (blocks == null || blocks.isEmpty()) return false;
+            return !blocks.contains(event.getBlock().getType());
+        }
+    }
+
+    public static BlockBreakFilterType parse(Match match, JsonObject jsonObject) {
         List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
         List<Region> regions = new ArrayList<>();
+        List<Material> blocks = new ArrayList<>();
 
         for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
             Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
@@ -57,9 +75,16 @@ public class EnterFilterType implements FilterType, Listener {
                 regions.add(region);
             }
         }
+        if (jsonObject.has("blocks"))
+            for (JsonElement materialElement : jsonObject.getAsJsonArray("blocks")) {
+                if (!materialElement.isJsonPrimitive()) continue;
+                Material material = Material.getMaterial(Strings.getTechnicalName(materialElement.getAsString()));
+                if (material == null) continue;
+                blocks.add(material);
+            }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
         String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
-        return new EnterFilterType(matchTeams, regions, filterEvaluator, message);
+        return new BlockBreakFilterType(matchTeams, regions, filterEvaluator, message, blocks);
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockBreakFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockBreakFilterType.java
@@ -47,7 +47,7 @@ public class BlockBreakFilterType implements FilterType, Listener {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
                         if (!canBreak(event, filterResult)) {
                             event.setCancelled(true);
-                            event.getPlayer().sendMessage(message);
+                            if (message != null) event.getPlayer().sendMessage(message);
                         }
                         break;
                     }
@@ -91,7 +91,7 @@ public class BlockBreakFilterType implements FilterType, Listener {
             }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
-        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        String message = jsonObject.has("message") ? ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString()) : null;
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new BlockBreakFilterType(matchTeams, regions, filterEvaluator, message, blocks, inverted);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockExplodeFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockExplodeFilterType.java
@@ -1,10 +1,15 @@
 package network.warzone.tgm.modules.filter.type;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.modules.filter.FilterManagerModule;
 import network.warzone.tgm.modules.filter.FilterResult;
 import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
 import network.warzone.tgm.modules.region.Region;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import network.warzone.tgm.modules.region.RegionManagerModule;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -38,6 +43,19 @@ public class BlockExplodeFilterType implements FilterType, Listener {
         for (Block block : cancelledBlocks){
             event.blockList().remove(block);
         }
+    }
+
+    public static BlockExplodeFilterType parse(Match match, JsonObject jsonObject) {
+        List<Region> regions = new ArrayList<>();
+        for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
+            Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
+            if (region != null) {
+                regions.add(region);
+            }
+        }
+
+        FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
+        return new BlockExplodeFilterType(regions, filterEvaluator);
     }
 
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockPlaceFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockPlaceFilterType.java
@@ -47,7 +47,7 @@ public class BlockPlaceFilterType implements FilterType, Listener {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
                         if (!canPlace(event, filterResult)) {
                             event.setCancelled(true);
-                            event.getPlayer().sendMessage(message);
+                            if (message != null) event.getPlayer().sendMessage(message);
                         }
                         break;
                     }
@@ -92,7 +92,7 @@ public class BlockPlaceFilterType implements FilterType, Listener {
             }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
-        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        String message = jsonObject.has("message") ? ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString()) : null;
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new BlockPlaceFilterType(matchTeams, regions, filterEvaluator, message, blocks, inverted);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockPlaceFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BlockPlaceFilterType.java
@@ -15,6 +15,7 @@ import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.util.Parser;
 import network.warzone.tgm.util.Strings;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -35,11 +36,12 @@ public class BlockPlaceFilterType implements FilterType, Listener {
     private final FilterEvaluator evaluator;
     private final String message;
     private final List<Material> blocks;
+    private final boolean inverted;
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onBlockPlaceEvent(BlockPlaceEvent event) {
         for (Region region : regions) {
-            if (region.contains(event.getBlockPlaced().getLocation())) {
+            if (contains(region, event.getBlockPlaced().getLocation())) {
                 for (MatchTeam matchTeam : teams) {
                     if (matchTeam.containsPlayer(event.getPlayer())) {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
@@ -52,6 +54,11 @@ public class BlockPlaceFilterType implements FilterType, Listener {
                 }
             }
         }
+    }
+
+    private boolean contains(Region region, Location location) {
+        if (!inverted) return region.contains(location);
+        else return !region.contains(location);
     }
 
 
@@ -86,7 +93,8 @@ public class BlockPlaceFilterType implements FilterType, Listener {
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
         String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
-        return new BlockPlaceFilterType(matchTeams, regions, filterEvaluator, message, blocks);
+        boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
+        return new BlockPlaceFilterType(matchTeams, regions, filterEvaluator, message, blocks, inverted);
     }
 
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BuildFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/BuildFilterType.java
@@ -49,7 +49,7 @@ public class BuildFilterType implements FilterType, Listener {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
                         if (filterResult == FilterResult.DENY) {
                             event.setCancelled(true);
-                            event.getPlayer().sendMessage(message);
+                            if (message != null) event.getPlayer().sendMessage(message);
                         } else if (filterResult == FilterResult.ALLOW) {
                             event.setCancelled(false);
                         }
@@ -202,7 +202,7 @@ public class BuildFilterType implements FilterType, Listener {
         }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
-        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        String message = jsonObject.has("message") ? ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString()) : null;
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new BuildFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/EnterFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/EnterFilterType.java
@@ -39,7 +39,7 @@ public class EnterFilterType implements FilterType, Listener {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
                         if (filterResult == FilterResult.DENY) {
                             event.setCancelled(true);
-                            event.getPlayer().sendMessage(message);
+                            if (message != null) event.getPlayer().sendMessage(message);
                         } else if (filterResult == FilterResult.ALLOW) {
                             event.setCancelled(false);
                         }
@@ -66,7 +66,7 @@ public class EnterFilterType implements FilterType, Listener {
         }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
-        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        String message = jsonObject.has("message") ? ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString()) : null;
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new EnterFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/LeaveFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/LeaveFilterType.java
@@ -41,7 +41,7 @@ public class LeaveFilterType implements FilterType, Listener {
                         FilterResult filterResult = evaluator.evaluate(event.getPlayer());
                         if (filterResult == FilterResult.DENY) {
                             event.setCancelled(true);
-                            event.getPlayer().sendMessage(message);
+                            if (message != null) event.getPlayer().sendMessage(message);
                         } else if (filterResult == FilterResult.ALLOW) {
                             event.setCancelled(false);
                         }
@@ -68,7 +68,7 @@ public class LeaveFilterType implements FilterType, Listener {
         }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
-        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        String message = jsonObject.has("message") ? ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString()) : null;
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new LeaveFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/LeaveFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/LeaveFilterType.java
@@ -1,15 +1,24 @@
 package network.warzone.tgm.modules.filter.type;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import net.md_5.bungee.api.ChatColor;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.modules.filter.FilterManagerModule;
 import network.warzone.tgm.modules.filter.FilterResult;
 import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
 import network.warzone.tgm.modules.region.Region;
+import network.warzone.tgm.modules.region.RegionManagerModule;
 import network.warzone.tgm.modules.team.MatchTeam;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.util.Parser;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @AllArgsConstructor @Getter
@@ -38,6 +47,22 @@ public class LeaveFilterType implements FilterType, Listener {
                 }
             }
         }
+    }
+
+    public static LeaveFilterType parse(Match match, JsonObject jsonObject) {
+        List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
+        List<Region> regions = new ArrayList<>();
+
+        for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
+            Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
+            if (region != null) {
+                regions.add(region);
+            }
+        }
+
+        FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
+        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        return new LeaveFilterType(matchTeams, regions, filterEvaluator, message);
     }
 
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseBowFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseBowFilterType.java
@@ -1,16 +1,24 @@
 package network.warzone.tgm.modules.filter.type;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.md_5.bungee.api.ChatColor;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.modules.filter.FilterManagerModule;
 import network.warzone.tgm.modules.filter.FilterResult;
 import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
 import network.warzone.tgm.modules.region.Region;
+import network.warzone.tgm.modules.region.RegionManagerModule;
 import network.warzone.tgm.modules.team.MatchTeam;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import org.bukkit.entity.Player;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.util.Parser;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityShootBowEvent;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -38,5 +46,21 @@ public class UseBowFilterType implements FilterType, Listener {
                 }
             }
         }
+    }
+
+    public static UseBowFilterType parse(Match match, JsonObject jsonObject) {
+        List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
+        List<Region> regions = new ArrayList<>();
+
+        for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
+            Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
+            if (region != null) {
+                regions.add(region);
+            }
+        }
+
+        FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
+        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        return new UseBowFilterType(matchTeams, regions, filterEvaluator, message);
     }
 }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseBowFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseBowFilterType.java
@@ -42,7 +42,7 @@ public class UseBowFilterType implements FilterType, Listener {
                 FilterResult filterResult = evaluator.evaluate(e.getEntity());
                 if (filterResult == FilterResult.DENY) {
                     e.setCancelled(true);
-                    e.getEntity().sendMessage(message);
+                    if (message != null) e.getEntity().sendMessage(message);
                 } else if (filterResult == FilterResult.ALLOW) {
                     e.setCancelled(false);
                 }
@@ -67,7 +67,7 @@ public class UseBowFilterType implements FilterType, Listener {
         }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
-        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        String message = jsonObject.has("message") ? ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString()) : null;
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new UseBowFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
@@ -44,7 +44,7 @@ public class UseShearFilterType implements FilterType, Listener {
                         FilterResult filterResult = evaluator.evaluate(e.getPlayer());
                         if (filterResult == FilterResult.DENY) {
                             e.setCancelled(true);
-                            e.getPlayer().sendMessage(message);
+                            if (message != null) e.getPlayer().sendMessage(message);
                         } else if (filterResult == FilterResult.ALLOW) {
                             e.setCancelled(false);
                         }
@@ -71,7 +71,7 @@ public class UseShearFilterType implements FilterType, Listener {
         }
 
         FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
-        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        String message = jsonObject.has("message") ? ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString()) : null;
         boolean inverted = jsonObject.has("inverted") && jsonObject.get("inverted").getAsBoolean();
         return new UseShearFilterType(matchTeams, regions, filterEvaluator, message, inverted);
     }

--- a/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/filter/type/UseShearFilterType.java
@@ -1,15 +1,24 @@
 package network.warzone.tgm.modules.filter.type;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.md_5.bungee.api.ChatColor;
+import network.warzone.tgm.match.Match;
+import network.warzone.tgm.modules.filter.FilterManagerModule;
 import network.warzone.tgm.modules.filter.FilterResult;
 import network.warzone.tgm.modules.filter.evaluate.FilterEvaluator;
 import network.warzone.tgm.modules.region.Region;
+import network.warzone.tgm.modules.region.RegionManagerModule;
 import network.warzone.tgm.modules.team.MatchTeam;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import network.warzone.tgm.modules.team.TeamManagerModule;
+import network.warzone.tgm.util.Parser;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -41,5 +50,21 @@ public class UseShearFilterType implements FilterType, Listener {
                 }
             }
         }
+    }
+
+    public static UseShearFilterType parse(Match match, JsonObject jsonObject) {
+        List<MatchTeam> matchTeams = Parser.getTeamsFromElement(match.getModule(TeamManagerModule.class), jsonObject.get("teams"));
+        List<Region> regions = new ArrayList<>();
+
+        for (JsonElement regionElement : jsonObject.getAsJsonArray("regions")) {
+            Region region = match.getModule(RegionManagerModule.class).getRegion(match, regionElement);
+            if (region != null) {
+                regions.add(region);
+            }
+        }
+
+        FilterEvaluator filterEvaluator = FilterManagerModule.initEvaluator(match, jsonObject);
+        String message = ChatColor.translateAlternateColorCodes('&', jsonObject.get("message").getAsString());
+        return new UseShearFilterType(matchTeams, regions, filterEvaluator, message);
     }
 }


### PR DESCRIPTION
- Made filter messages optional
- Added more flexibility for filter types (can now detect `filterType`, `filter-type`, `filter_type` or `filter type`)
- Moved parsers into the filter classes
- Added 2 new filters that lets you control these events individually:
    - Block break (you may include a list of blocks that players can or cannot break).
    - Block place  (you may include a list of blocks that players can or cannot break).
### Examples
Disallow breaking of beacons through the `block break` filter
```JSON
		{
			"type": "blockBreak", "evaluate": "deny", 
			"teams": ["blue", "red"],
			"regions": ["global"],
			"message": "&cYou may not break enchanting tables.",
			"blocks": ["enchanting table"]
		},
```

Only allow placement of glass through the `block place` filter
```JSON
		{
			"type": "blockPlace", "evaluate": "allow", 
			"teams": ["blue", "red"],
			"regions": ["global"],
			"message": "&cYou may only place glass.",
			"blocks": ["glass"]
		},
```