### PR TITLE
Server address on scoreboard

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/blitz/BlitzModule.java
@@ -126,7 +126,7 @@ public class BlitzModule extends MatchModule implements Listener {
         SimpleScoreboard simpleScoreboard = event.getSimpleScoreboard();
         simpleScoreboard.setTitle(ChatColor.AQUA + "Players");
 
-        int i = 0;
+        int i = 2;
         for (MatchTeam matchTeam : teams) {
             if (matchTeam.isSpectator()) continue;
             simpleScoreboard.add(matchTeam.getColor() + getTeamScoreLine(matchTeam, getAlivePlayers(matchTeam).size()), i);

--- a/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ctw/CTWModule.java
@@ -177,7 +177,7 @@ public class CTWModule extends MatchModule implements Listener {
         List<MatchTeam> teams = TGM.get().getModule(TeamManagerModule.class).getTeams();
 
         int spaceCount = 1;
-        int i = 0;
+        int i = 2;
         for (MatchTeam matchTeam : teams) {
             if(matchTeam.isSpectator()) continue;
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/dtm/DTMModule.java
@@ -145,7 +145,7 @@ public class DTMModule extends MatchModule implements Listener {
         List<MatchTeam> teams = TGM.get().getModule(TeamManagerModule.class).getTeams();
 
         int spaceCount = 1;
-        int i = 0;
+        int i = 2;
         for (MatchTeam matchTeam : teams) {
             if(matchTeam.isSpectator()) continue;
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/ffa/FFAModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/ffa/FFAModule.java
@@ -183,7 +183,7 @@ public class FFAModule extends MatchModule implements Listener {
 
     private void refreshScoreboard(SimpleScoreboard simpleScoreboard) {
         simpleScoreboard.setTitle(ChatColor.translateAlternateColorCodes('&', title));
-        int line = 0;
+        int line = 2;
         for (int i : playerScoreboardLines.keySet()) {
             simpleScoreboard.add(playerScoreboardLines.get(i), i);
             if (i > line) line = i;

--- a/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/infection/InfectionModule.java
@@ -135,7 +135,7 @@ public class InfectionModule extends MatchModule implements Listener, TimeSubscr
     private void defaultScoreboard() {
         teamScoreboardLines.clear();
         teamAliveScoreboardLines.clear();
-        int positionOnScoreboard = 0;
+        int positionOnScoreboard = 1;
         int spaceCount = 1;
         for(MatchTeam team : teamManager.getTeams()) {
             if(team.isSpectator()) continue;

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -128,22 +128,26 @@ public class KOTHModule extends MatchModule implements Listener {
         SimpleScoreboard simpleScoreboard = event.getSimpleScoreboard();
 
         int i;
+        int j = 2;
         for (i = 0; i < controlPoints.size(); i++) {
             ControlPoint controlPoint = controlPoints.get(i);
 
-            controlPointScoreboardLines.put(controlPoint.getDefinition(), i);
-            simpleScoreboard.add(getControlPointScoreboardLine(controlPoint), i);
+            controlPointScoreboardLines.put(controlPoint.getDefinition(), j);
+            simpleScoreboard.add(getControlPointScoreboardLine(controlPoint), j);
+            j++;
         }
 
         i++;
-        simpleScoreboard.add(" ", i);
+        simpleScoreboard.add(" ", j);
 
         i++;
         for (MatchTeam matchTeam : teams) {
             if (matchTeam.isSpectator()) continue;
 
-            simpleScoreboard.add(getTeamScoreLine(matchTeam), i);
-            teamScoreboardLines.put(matchTeam, i);
+            j++;
+
+            simpleScoreboard.add(getTeamScoreLine(matchTeam), j);
+            teamScoreboardLines.put(matchTeam, j);
 
             i++;
         }

--- a/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/koth/KOTHModule.java
@@ -127,20 +127,14 @@ public class KOTHModule extends MatchModule implements Listener {
         List<MatchTeam> teams = TGM.get().getModule(TeamManagerModule.class).getTeams();
         SimpleScoreboard simpleScoreboard = event.getSimpleScoreboard();
 
-        int i;
         int j = 2;
-        for (i = 0; i < controlPoints.size(); i++) {
-            ControlPoint controlPoint = controlPoints.get(i);
-
+        for (ControlPoint controlPoint : controlPoints) {
             controlPointScoreboardLines.put(controlPoint.getDefinition(), j);
             simpleScoreboard.add(getControlPointScoreboardLine(controlPoint), j);
             j++;
         }
-
-        i++;
         simpleScoreboard.add(" ", j);
 
-        i++;
         for (MatchTeam matchTeam : teams) {
             if (matchTeam.isSpectator()) continue;
 
@@ -148,8 +142,6 @@ public class KOTHModule extends MatchModule implements Listener {
 
             simpleScoreboard.add(getTeamScoreLine(matchTeam), j);
             teamScoreboardLines.put(matchTeam, j);
-
-            i++;
         }
     }
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/ScoreboardManagerModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/scoreboard/ScoreboardManagerModule.java
@@ -96,9 +96,10 @@ public class ScoreboardManagerModule extends MatchModule implements Listener {
 
         Bukkit.getPluginManager().callEvent(new ScoreboardInitEvent(playerContext.getPlayer(), simpleScoreboard));
 
+        simpleScoreboard.add(" ", 1);
+        simpleScoreboard.add(ChatColor.YELLOW + ChatColor.translateAlternateColorCodes('&', TGM.get().getConfig().getString("server.ip") == null ? "play.warz.one" : TGM.get().getConfig().getString("server.ip")), 0);
         simpleScoreboard.send(playerContext.getPlayer());
         scoreboards.put(playerContext.getPlayer().getUniqueId(), simpleScoreboard);
-
         simpleScoreboard.update();
 
         return simpleScoreboard;

--- a/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/tdm/TDMModule.java
@@ -84,7 +84,7 @@ public class TDMModule extends MatchModule implements Listener {
 
         SimpleScoreboard simpleScoreboard = event.getSimpleScoreboard();
 
-        int i = 0;
+        int i = 2;
         for (MatchTeam matchTeam : teams) {
             if (matchTeam.isSpectator()) continue;
             simpleScoreboard.add(matchTeam.getColor() + getTeamScoreLine(matchTeam), i);

--- a/TGM/src/main/resources/config.yml
+++ b/TGM/src/main/resources/config.yml
@@ -45,6 +45,8 @@ server:
   # ID for the server object served by the API.
   # Default: Warzone
   id: "warzone"
+  # Displayed on the scoreboard. Feel free to use color codes if you don't want yellow text.
+  ip: "play.warz.one"
   # Store link displayed when a player tries to join a specific team.
   store: "https://tgmwarzone.tebex.io/"
   # Text displayed after the match time on the tablist header.


### PR DESCRIPTION
Lets server owners display a server address at the bottom of the scoreboard that can be edited in the config file including colour codes if they don't want yellow text by default. Defaults to `play.warz.one` in yellow.

I tested this on at least one map in each category from the map repository.

Resolves #449 