### PR TITLE
Begin to generalise chat messages

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/api/ApiManager.java
@@ -6,7 +6,7 @@ import network.warzone.tgm.map.MapInfo;
 import network.warzone.tgm.map.ParsedTeam;
 import network.warzone.tgm.match.MatchLoadEvent;
 import network.warzone.tgm.match.MatchResultEvent;
-import network.warzone.tgm.modules.ChatModule;
+import network.warzone.tgm.modules.chat.ChatModule;
 import network.warzone.tgm.modules.death.DeathInfo;
 import network.warzone.tgm.modules.death.DeathModule;
 import network.warzone.tgm.modules.StatsModule;

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -13,6 +13,7 @@ import network.warzone.tgm.map.MapInfo;
 import network.warzone.tgm.match.MatchManager;
 import network.warzone.tgm.match.MatchStatus;
 import network.warzone.tgm.modules.chat.ChatChannel;
+import network.warzone.tgm.modules.chat.ChatConstant;
 import network.warzone.tgm.modules.chat.ChatModule;
 import network.warzone.tgm.modules.countdown.Countdown;
 import network.warzone.tgm.modules.countdown.CycleCountdown;
@@ -289,7 +290,7 @@ public class CycleCommands {
     @Command(aliases = {"classes"}, desc = "Class menu.")
     public static void classes(CommandContext cmd, CommandSender sender) {
         if(!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "You must be a player to do that.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         if (TGM.get().getModule(GameClassModule.class) == null) {
@@ -305,7 +306,7 @@ public class CycleCommands {
     @Command(aliases = {"class"}, desc = "Choose a class.", min = 1, usage = "<kit name>")
     public static void classCommand(CommandContext cmd, CommandSender sender) {
         if(!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "You must be a player to do this.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         if (TGM.get().getModule(GameClassModule.class) == null) {
@@ -348,7 +349,7 @@ public class CycleCommands {
     @Command(aliases = {"join", "play"}, desc = "Join a team.")
     public static void join(CommandContext cmd, CommandSender sender) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "You must be a player to do that.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         TeamManagerModule teamManager = TGM.get().getModule(TeamManagerModule.class);
@@ -419,7 +420,7 @@ public class CycleCommands {
     @Command(aliases = {"killstreak", "ks"}, desc = "See your current killstreak")
     public static void killstreak(CommandContext cmd, CommandSender sender) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "Only players can use this command");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         Player player = (Player) sender;
@@ -442,7 +443,7 @@ public class CycleCommands {
     @Command(aliases = {"teleport", "tp"}, desc = "Teleport to a player")
     public static void teleport(CommandContext cmd, CommandSender sender) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         Player player = (Player) sender;
@@ -545,7 +546,7 @@ public class CycleCommands {
     @Command(aliases = {"channel", "chatchannel", "cc"}, desc = "Change or select a chat channel.", usage = "(all|team|staff)", min = 1)
     public static void channel(CommandContext cmd, CommandSender sender) {
         if(!(sender instanceof Player)) {
-            sender.sendMessage("Error: Only players can use this command.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         Player player = (Player) sender;
@@ -574,7 +575,7 @@ public class CycleCommands {
     @Command(aliases = {"t"}, desc = "Send a message to your team.", usage = "(message)", min = 1)
     public static void t(CommandContext cmd, CommandSender sender) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "You must be a player to do that.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         if (cmd.argsLength() > 0) {

--- a/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/CycleCommands.java
@@ -12,7 +12,8 @@ import network.warzone.tgm.map.MapContainer;
 import network.warzone.tgm.map.MapInfo;
 import network.warzone.tgm.match.MatchManager;
 import network.warzone.tgm.match.MatchStatus;
-import network.warzone.tgm.modules.ChatModule;
+import network.warzone.tgm.modules.chat.ChatChannel;
+import network.warzone.tgm.modules.chat.ChatModule;
 import network.warzone.tgm.modules.countdown.Countdown;
 import network.warzone.tgm.modules.countdown.CycleCountdown;
 import network.warzone.tgm.modules.countdown.StartCountdown;
@@ -554,10 +555,10 @@ public class CycleCommands {
         }
 
         String channelName = cmd.getString(0).toUpperCase();
-        ChatModule.Channel channel = ChatModule.Channel.byName(channelName);
+        ChatChannel channel = ChatChannel.byName(channelName);
         if (channel == null) {
           player.sendMessage(ColorConverter.filterString("&cInvalid channel: " + channelName));
-          player.sendMessage(ColorConverter.filterString("&cChannels: ( " + StringUtils.join(Arrays.stream(ChatModule.Channel.values()).filter(ch -> ch.hasPermission(player)).collect(Collectors.toList()), " | ")) + " )");
+          player.sendMessage(ColorConverter.filterString("&cChannels: ( " + StringUtils.join(Arrays.stream(ChatChannel.values()).filter(ch -> ch.hasPermission(player)).collect(Collectors.toList()), " | ")) + " )");
           return;
         }
 

--- a/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
@@ -6,6 +6,7 @@ import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandNumberFormatException;
 import com.sk89q.minecraft.util.commands.CommandPermissions;
 import network.warzone.tgm.TGM;
+import network.warzone.tgm.modules.chat.ChatConstant;
 import network.warzone.tgm.nickname.NickManager;
 import network.warzone.tgm.nickname.NickedUserProfile;
 import network.warzone.tgm.util.HashMaps;
@@ -52,7 +53,7 @@ public class NickCommands {
     @CommandPermissions({"tgm.command.nick"})
     public static void nick(CommandContext cmd, CommandSender sender) throws IllegalAccessException, NoSuchFieldException, UnirestException {
         if (!(sender instanceof Player)) {
-            sender.sendMessage("Player only command.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
         Player p = (Player) sender;

--- a/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/NickCommands.java
@@ -132,7 +132,7 @@ public class NickCommands {
                 try {
                     TGM.get().getNickManager().setName(p, newName);
                 } catch (NoSuchFieldException | IllegalAccessException e) {
-                    p.sendMessage(NickManager.RATELIMITED_MESSAGE);
+                    p.sendMessage(ChatConstant.ERROR_RATE_LIMITED.toString());
                 }
                 sender.sendMessage(ChatColor.GREEN + "Updated username to " + ChatColor.YELLOW + newName);
             } else if (option.equals("stats") && cmd.argsLength() > 1) {

--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -3,6 +3,7 @@ package network.warzone.tgm.command;
 import com.sk89q.minecraft.util.commands.*;
 import net.md_5.bungee.api.chat.*;
 import network.warzone.tgm.TGM;
+import network.warzone.tgm.modules.chat.ChatConstant;
 import network.warzone.tgm.modules.reports.Report;
 import network.warzone.tgm.modules.reports.ReportsModule;
 import network.warzone.tgm.util.TimeUnitPair;
@@ -327,7 +328,7 @@ public class PunishCommands {
     @Command(aliases = {"report"}, desc = "Report a player", min = 2, usage = "(name) (reason...)")
     public static void report(CommandContext cmd, CommandSender sender) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            sender.sendMessage(ChatConstant.ERROR_COMMAND_PLAYERS_ONLY.toString());
             return;
         }
 

--- a/TGM/src/main/java/network/warzone/tgm/command/RankCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/RankCommands.java
@@ -9,7 +9,7 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import network.warzone.tgm.TGM;
-import network.warzone.tgm.modules.ChatModule;
+import network.warzone.tgm.modules.chat.ChatModule;
 import network.warzone.tgm.user.PlayerContext;
 import network.warzone.tgm.util.Ranks;
 import network.warzone.warzoneapi.models.*;

--- a/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import net.md_5.bungee.api.ChatColor;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.match.MatchPostLoadEvent;
+import network.warzone.tgm.modules.chat.ChatConstant;
 import network.warzone.tgm.modules.chat.ChatModule;
 import network.warzone.tgm.nickname.NickManager;
 import network.warzone.tgm.nickname.QueuedNick;
@@ -123,7 +124,7 @@ public class JoinManager implements Listener {
                 try {
                     nickManager.reset(player, false);
                 } catch (NoSuchFieldException | IllegalAccessException | UnirestException e) {
-                    p.sendMessage(NickManager.RATELIMITED_MESSAGE);
+                    p.sendMessage(ChatConstant.ERROR_RATE_LIMITED.toString());
                 }
             }
         }
@@ -160,7 +161,7 @@ public class JoinManager implements Listener {
                 try {
                     nickManager.reset(p, false);
                 } catch (NoSuchFieldException | IllegalAccessException | UnirestException e) {
-                    p.sendMessage(NickManager.RATELIMITED_MESSAGE);
+                    p.sendMessage(ChatConstant.ERROR_RATE_LIMITED.toString());
                 }
                 // Invalidate the nick.
                 name = null;

--- a/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/join/JoinManager.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import net.md_5.bungee.api.ChatColor;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.match.MatchPostLoadEvent;
-import network.warzone.tgm.modules.ChatModule;
+import network.warzone.tgm.modules.chat.ChatModule;
 import network.warzone.tgm.nickname.NickManager;
 import network.warzone.tgm.nickname.QueuedNick;
 import network.warzone.warzoneapi.models.Skin;

--- a/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
+++ b/TGM/src/main/java/network/warzone/tgm/match/MatchManifest.java
@@ -1,9 +1,9 @@
 package network.warzone.tgm.match;
 
 import com.google.gson.JsonObject;
-import network.warzone.tgm.map.MapInfo;
 import network.warzone.tgm.modules.*;
 import network.warzone.tgm.modules.border.WorldBorderModule;
+import network.warzone.tgm.modules.chat.ChatModule;
 import network.warzone.tgm.modules.countdown.CycleCountdown;
 import network.warzone.tgm.modules.countdown.StartCountdown;
 import network.warzone.tgm.modules.damage.DamageControlModule;

--- a/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatChannel.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatChannel.java
@@ -1,0 +1,26 @@
+package network.warzone.tgm.modules.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.bukkit.entity.Player;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public enum ChatChannel {
+        ALL, TEAM, STAFF("tgm.staffchat");
+
+        private String permission;
+
+        public boolean hasPermission(Player player) {
+            return permission == null || player.hasPermission(permission);
+        }
+
+        public static ChatChannel byName(String name) {
+            for (ChatChannel channel : values()) {
+                if (channel.name().equalsIgnoreCase(name)) {
+                    return channel;
+                }
+            }
+            return null;
+        }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatConstant.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatConstant.java
@@ -3,7 +3,8 @@ package network.warzone.tgm.modules.chat;
 import net.md_5.bungee.api.ChatColor;
 
 public enum ChatConstant {
-    ERROR_COMMAND_PLAYERS_ONLY(ChatColor.RED + "You must be a player to run this command!");
+    ERROR_COMMAND_PLAYERS_ONLY(ChatColor.RED + "You must be a player to run this command!"),
+    ERROR_RATE_LIMITED(ChatColor.RED + "Slow down! You're being rate limited.");
 
     private final String message;
 

--- a/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatConstant.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatConstant.java
@@ -1,0 +1,18 @@
+package network.warzone.tgm.modules.chat;
+
+import net.md_5.bungee.api.ChatColor;
+
+public enum ChatConstant {
+    ERROR_COMMAND_PLAYERS_ONLY(ChatColor.RED + "You must be a player to run this command!");
+
+    private final String message;
+
+    ChatConstant(final String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return message;
+    }
+}

--- a/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatModule.java
+++ b/TGM/src/main/java/network/warzone/tgm/modules/chat/ChatModule.java
@@ -1,14 +1,13 @@
-package network.warzone.tgm.modules;
+package network.warzone.tgm.modules.chat;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import network.warzone.tgm.TGM;
 import network.warzone.tgm.match.Match;
 import network.warzone.tgm.match.MatchModule;
+import network.warzone.tgm.modules.StatsModule;
 import network.warzone.tgm.modules.team.MatchTeam;
 import network.warzone.tgm.modules.team.TeamManagerModule;
 import network.warzone.tgm.modules.time.TimeModule;
@@ -30,30 +29,10 @@ import java.util.*;
 @Getter
 public class ChatModule extends MatchModule implements Listener {
 
-    @AllArgsConstructor @NoArgsConstructor
-    public enum Channel {
-        ALL, TEAM, STAFF("tgm.staffchat");
-
-        private String permission;
-
-        public boolean hasPermission(Player player) {
-            return permission == null || player.hasPermission(permission);
-        }
-
-        public static Channel byName(String name) {
-            for (Channel channel : values()) {
-                if (channel.name().equalsIgnoreCase(name)) {
-                    return channel;
-                }
-            }
-            return null;
-        }
-    }
-
     private TeamManagerModule teamManagerModule;
     private TimeModule timeModule;
     private final List<Chat> chatLog = new ArrayList<>();
-    private static final Map<String, Channel> channels = new HashMap<>();
+    private static final Map<String, ChatChannel> channels = new HashMap<>();
 
     @Override
     public void load(Match match) {
@@ -61,7 +40,7 @@ public class ChatModule extends MatchModule implements Listener {
         timeModule = match.getModule(TimeModule.class);
     }
 
-    public static Map<String, Channel> getChannels() {
+    public static Map<String, ChatChannel> getChannels() {
         return channels;
     }
 
@@ -102,18 +81,18 @@ public class ChatModule extends MatchModule implements Listener {
         }
 
         if(!(channels.containsKey(event.getPlayer().getUniqueId().toString()))) {
-            channels.put(event.getPlayer().getUniqueId().toString(), Channel.ALL);
+            channels.put(event.getPlayer().getUniqueId().toString(), ChatChannel.ALL);
         }
 
-        Channel channel = channels.get(event.getPlayer().getUniqueId().toString());
+        ChatChannel channel = channels.get(event.getPlayer().getUniqueId().toString());
 
-        if(channel == Channel.TEAM) {
+        if(channel == ChatChannel.TEAM) {
             TGM.get().getModule(ChatModule.class).sendTeamChat(playerContext, event.getMessage());
             event.setCancelled(true);
             return;
         }
 
-        if(channel == Channel.STAFF) {
+        if(channel == ChatChannel.STAFF) {
             String prefix;
             prefix = playerContext.getUserProfile().getPrefix() != null ? ChatColor.translateAlternateColorCodes('&', playerContext.getUserProfile().getPrefix().trim()) + " " : "";
 
@@ -122,7 +101,7 @@ public class ChatModule extends MatchModule implements Listener {
             return;
         }
 
-        if (channel == Channel.ALL) {
+        if (channel == ChatChannel.ALL) {
             MatchTeam matchTeam = teamManagerModule.getTeam(event.getPlayer());
             String prefix = playerContext.getUserProfile().getPrefix() != null ? ChatColor.translateAlternateColorCodes('&', playerContext.getUserProfile().getPrefix().trim()) + " " : "";
             event.setFormat((TGM.get().getModule(StatsModule.class).isStatsDisabled() ? "" : playerContext.getLevelString() + " ") +

--- a/TGM/src/main/java/network/warzone/tgm/nickname/NickManager.java
+++ b/TGM/src/main/java/network/warzone/tgm/nickname/NickManager.java
@@ -31,8 +31,6 @@ import java.util.*;
 
 public class NickManager {
 
-    public static String RATELIMITED_MESSAGE = ChatColor.GOLD.toString() + ChatColor.BOLD + "Slow Down! " + ChatColor.RESET.toString() + ChatColor.RED + "You're being ratelimited.";
-
     private VisibilityController visiblityController;
 
     @Getter


### PR DESCRIPTION
I made an enum for constant chat messages, which we can hopefully expand in the future so the majority of chat messages are generalised. This will also come in handy for when we decide to introduce internationalisation (i18n) to TGM.

This PR includes consistent error messages for "player-only commands" when Console tries to use them.