### PR TITLE
Correct ambient parser

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/parser/effect/tag/EffectAmbientParser.java
+++ b/TGM/src/main/java/network/warzone/tgm/parser/effect/tag/EffectAmbientParser.java
@@ -9,6 +9,6 @@ public class EffectAmbientParser implements EffectTagParser<Boolean> {
 
     @Override
     public Boolean parse(JsonObject object) {
-        return !object.has("duration") || object.get("duration").getAsBoolean();
+        return !object.has("ambient") || object.get("ambient").getAsBoolean();
     }
 }


### PR DESCRIPTION
Had `duration` before instead of `ambient`