### PR TITLE
Add Discord suggestion in report received message.

### DIFF
--- a/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
+++ b/TGM/src/main/java/network/warzone/tgm/command/PunishCommands.java
@@ -476,7 +476,7 @@ public class PunishCommands {
             TGM.get().getTeamClient().createReport(new ReportCreateRequest(amount, reportedName, reporter.getName(), reporter.getUniqueId(), reported.getUniqueId(), report.getReason(), report.getTimestamp() / 1000, onlineStaff))
         );
 
-        reporter.sendMessage(ChatColor.GREEN + "Your report has been sent to online staff.");
+        reporter.sendMessage(ChatColor.GREEN + "Your report has been sent to online staff. You can also report players in our Discord server if staff are unavailable.");
     }
 
     @Command(aliases = {"reports"}, desc = "View reports", max = 1, usage = "[page]")


### PR DESCRIPTION
When a player successfully sends a report, the report received message now suggests players send reports within the Discord server if staff are offline and unavailable at the moment.

While it would be more convenient for players to know if there _are_ staff currently online or not and if they should contact moderators within the Discord server instead, some would exploit that privilege and break rules specifically when staff are offline.